### PR TITLE
Add magazine and zine style packs (0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-06-11
+
+### Added
+- `magazine` style pack — long-read essay page (serif body on the Palatino/Georgia chain, kicker/dek/byline header, pull quotes, raised-cap lede, end mark)
+- `zine` style pack — pocket how-to guide (half-letter page, marker display type, checkbox steps, command blocks, warning boxes; print 2-up on Letter for folding)
+
+### Fixed
+- Avoided a WeasyPrint crash on floated `::first-letter` (drop caps render as raised caps instead)
+
 ## [0.2.0] - 2026-06-11
 
 ### Added

--- a/docs/composing.md
+++ b/docs/composing.md
@@ -17,6 +17,8 @@ morning-paper styles   # list available styles + palettes
 | `typewriter` | The newspaper: Courier Prime masthead, card sections, two-column HN-style cards. |
 | `flow` | The continuous operator brief: dense, sections run together, no forced page breaks. |
 | `ops-card` | The boxed reference one-pager: scripts, checklists, do/don't splits, dense tables. |
+| `magazine` | The long-read essay page: serif body, kicker/dek/byline, pull quotes, wide margins. |
+| `zine` | The pocket how-to guide: half-letter, marker display type, checkbox steps, command blocks. |
 
 ## Palettes
 
@@ -93,6 +95,10 @@ file (`src/morning_paper/resources/styles/`). The most portable ones:
   `.oc-split`/`.oc-col` (do/don't), `.oc-foot`
 - `typewriter`: `.page-1-header`, `.info-row`, `.tweet`/`.tweet-pair`,
   `.hn-cards`/`.hn-card`, `.featured-reads`/`.full-read`, `.action-required`
+- `magazine`: `.mg-kicker`, `.mg-title`, `.mg-dek`, `.mg-byline`, `.mg-lede`,
+  `.mg-pull`/`.mg-pull-attr`, `.mg-note`, `.mg-end`
+- `zine`: `.zn-cover`/`.zn-cover-title`/`.zn-cover-sub`/`.zn-cover-meta`,
+  `.zn-step` (checkbox lines), `.zn-cmd`, `.zn-url`, `.zn-img`, `.zn-warn`
 
 Honesty rule (engine doctrine): a section with no data says so
 (`.not-configured`) — composition degrades, it never fabricates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.2.0"
+version = "0.2.1"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/src/morning_paper/resources/styles/magazine.css
+++ b/src/morning_paper/resources/styles/magazine.css
@@ -1,0 +1,170 @@
+/* Style pack: magazine — the long-read essay page.
+ * Modeled on every.to's print-friendly article typography (studied
+ * 2026-06-10): Signifier serif body with Palatino/Georgia fallbacks (we use
+ * the license-free fallback chain directly), sans kickers, generous measure
+ * and leading, pull quotes, restrained accent color. One column, wide
+ * margins; built for reading, not scanning.
+ * Consumes palette tokens; compose with a palette sheet.
+ */
+
+:root {
+  --mg-serif: 'Palatino', 'Palatino Linotype', 'Book Antiqua', Georgia, 'Times New Roman', serif;
+  --mg-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --mg-body: 10.5pt;
+  --mg-lh: 1.58;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+@page {
+  size: Letter;
+  margin: 0.85in 1in 0.95in 1in;
+  @bottom-left  { content: string(mp-date); font-family: Helvetica, Arial, sans-serif; font-size: 7pt; letter-spacing: 0.04em; color: #888888; }
+  @bottom-center{ content: string(mp-name); font-family: Helvetica, Arial, sans-serif; font-size: 7pt; letter-spacing: 0.1em; text-transform: uppercase; color: #888888; }
+  @bottom-right { content: counter(page); font-family: 'Palatino', Georgia, serif; font-size: 9pt; color: #555555; }
+}
+
+.mp-footer-date, .mp-footer-name {
+  display: block; height: 0; overflow: hidden;
+  font-size: 0; line-height: 0; visibility: hidden;
+}
+.mp-footer-date { string-set: mp-date content(); }
+.mp-footer-name { string-set: mp-name content(); }
+
+body {
+  font-family: var(--mg-serif);
+  font-size: var(--mg-body);
+  line-height: var(--mg-lh);
+  color: var(--mp-ink);
+  background: var(--mp-paper);
+}
+
+/* article header */
+.mg-kicker {
+  font-family: var(--mg-sans);
+  font-size: 8pt;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--mp-chart-ink);
+  margin-bottom: 0.12in;
+}
+.mg-title {
+  font-family: var(--mg-serif);
+  font-size: 26pt;
+  font-weight: 700;
+  line-height: 1.16;
+  letter-spacing: -0.01em;
+  margin-bottom: 0.12in;
+}
+.mg-dek {
+  font-family: var(--mg-serif);
+  font-style: italic;
+  font-size: 12.5pt;
+  line-height: 1.45;
+  color: var(--mp-muted);
+  margin-bottom: 0.14in;
+}
+.mg-byline {
+  font-family: var(--mg-sans);
+  font-size: 8pt;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mp-muted);
+  padding: 0.06in 0;
+  border-top: 1px solid var(--mp-rule);
+  border-bottom: 1px solid var(--mp-rule);
+  margin-bottom: 0.22in;
+}
+.mg-byline strong { color: var(--mp-ink); font-weight: 700; }
+
+/* body */
+p { margin-bottom: 0.11in; }
+p + p { text-indent: 0; }
+/* Raised cap, not a dropped cap: WeasyPrint asserts on floated
+   ::first-letter (layout/float.py), so the initial stays in-line. */
+.mg-lede::first-letter {
+  font-size: 15pt;
+  font-weight: 700;
+}
+
+h1, h2 {
+  font-family: var(--mg-sans);
+  font-size: 11pt;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  margin: 0.22in 0 0.08in 0;
+}
+h1 .sec-id { float: right; font-size: 7.5pt; color: var(--mp-muted); font-weight: 700; }
+
+/* pull quote */
+.mg-pull {
+  font-family: var(--mg-serif);
+  font-style: italic;
+  font-size: 15pt;
+  line-height: 1.4;
+  color: var(--mp-ink);
+  border-left: 3px solid var(--mp-chart-ink);
+  padding: 0.04in 0 0.04in 0.18in;
+  margin: 0.18in 0.1in 0.18in 0;
+  break-inside: avoid;
+}
+.mg-pull-attr {
+  display: block;
+  font-family: var(--mg-sans);
+  font-style: normal;
+  font-size: 7.5pt;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--mp-muted);
+  margin-top: 0.05in;
+}
+
+blockquote {
+  font-style: italic;
+  color: var(--mp-ink);
+  border-left: 2px solid var(--mp-track);
+  padding-left: 0.15in;
+  margin: 0.1in 0 0.12in 0.05in;
+}
+
+/* notes, asides, honest degradation */
+.mg-note {
+  font-family: var(--mg-sans);
+  font-size: 8.5pt;
+  line-height: 1.5;
+  color: var(--mp-muted);
+  background: var(--mp-card-bg);
+  padding: 0.08in 0.12in;
+  margin: 0.12in 0;
+  break-inside: avoid;
+}
+.not-configured {
+  font-family: var(--mg-sans);
+  margin: 0.1in 0; padding: 0.07in 0.1in;
+  border: 1px dashed var(--mp-muted);
+  font-size: 8.5pt; color: var(--mp-muted); line-height: 1.45;
+}
+
+/* charts inherit wrapper styling */
+.mp-chart { margin: 0.14in 0; break-inside: avoid; }
+.mp-chart-title { font-family: var(--mg-sans); font-size: 7.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mp-muted); margin-bottom: 0.04in; }
+.mp-chart svg { display: block; width: 100%; height: auto; }
+.mp-stats { display: flex; gap: 0.12in; margin: 0.1in 0; flex-wrap: wrap; }
+.mp-stat { flex: 1 1 0; min-width: 1.1in; border-top: 2px solid var(--mp-rule); padding: 0.06in 0.02in 0 0.02in; }
+.mp-stat-value { font-family: var(--mg-serif); font-size: 17pt; font-weight: 700; line-height: 1.05; color: var(--mp-chart-ink); }
+.mp-stat-delta { font-family: var(--mg-sans); font-size: 7pt; color: var(--mp-muted); margin-top: 0.012in; }
+.mp-stat-label { font-family: var(--mg-sans); font-size: 6.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mp-muted); margin-top: 0.02in; }
+
+table.data { width: 100%; border-collapse: collapse; margin: 0.08in 0; font-family: var(--mg-sans); font-size: 8.5pt; }
+table.data th { text-align: left; font-size: 7pt; text-transform: uppercase; letter-spacing: 0.06em; color: var(--mp-muted); border-bottom: 1px solid var(--mp-rule); padding: 0.02in 0.06in 0.02in 0; }
+table.data td { padding: 0.025in 0.06in 0.025in 0; border-bottom: 1px solid var(--mp-track); vertical-align: top; line-height: 1.4; }
+
+ul, ol { margin: 0.03in 0 0.1in 0.25in; }
+li { line-height: 1.5; margin-bottom: 0.03in; }
+a { color: var(--mp-chart-ink); text-decoration: none; }
+em { font-style: italic; }
+.page-break { page-break-before: always; }
+
+/* end mark */
+.mg-end::after { content: " ◼"; color: var(--mp-chart-ink); font-size: 9pt; }

--- a/src/morning_paper/resources/styles/zine.css
+++ b/src/morning_paper/resources/styles/zine.css
@@ -1,0 +1,145 @@
+/* Style pack: zine — the pocket how-to guide.
+ * Modeled on the Iffy Books Meshtastic zine (CC0, studied 2026-06-10):
+ * half-letter page, brush-marker display type, single readable column,
+ * checkbox task steps, centered bold URLs, bordered photos. Built to be
+ * stapled, folded, and handed to someone.
+ * Consumes palette tokens; compose with a palette sheet.
+ * Print note: half-letter pages 2-up on Letter = pdfbook2 / `lp -o number-up=2`.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Permanent+Marker&family=Open+Sans:ital,wght@0,400;0,700;1,400&display=swap');
+
+:root {
+  --zn-display: 'Permanent Marker', 'Marker Felt', 'Comic Sans MS', cursive;
+  --zn-body-font: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --zn-body: 9.5pt;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+@page {
+  /* half-letter: 5.5in x 8.5in */
+  size: 396pt 612pt;
+  margin: 0.45in 0.45in 0.55in 0.45in;
+  @bottom-center { content: counter(page); font-family: 'Open Sans', Helvetica, sans-serif; font-size: 8pt; color: #555555; }
+}
+
+.mp-footer-date, .mp-footer-name {
+  display: block; height: 0; overflow: hidden;
+  font-size: 0; line-height: 0; visibility: hidden;
+}
+.mp-footer-date { string-set: mp-date content(); }
+.mp-footer-name { string-set: mp-name content(); }
+
+body {
+  font-family: var(--zn-body-font);
+  font-size: var(--zn-body);
+  line-height: 1.48;
+  color: var(--mp-ink);
+  background: var(--mp-paper);
+}
+
+/* cover */
+.zn-cover { text-align: center; padding-top: 0.6in; }
+.zn-cover-title {
+  font-family: var(--zn-display);
+  font-size: 27pt;
+  line-height: 1.3;
+  margin-bottom: 0.25in;
+}
+.zn-cover-sub {
+  font-family: var(--zn-display);
+  font-size: 14pt;
+  margin-bottom: 0.08in;
+}
+.zn-cover-meta {
+  font-size: 9pt;
+  font-weight: 700;
+  font-style: italic;
+  margin-top: 0.3in;
+  line-height: 1.6;
+}
+.zn-cover-blurb { text-align: left; margin-top: 0.35in; font-size: 9.5pt; }
+
+/* section heads: centered, bold, caps (inner pages) */
+h1 {
+  font-family: var(--zn-body-font);
+  font-size: 12pt;
+  font-weight: 700;
+  text-transform: uppercase;
+  text-align: center;
+  letter-spacing: 0.02em;
+  margin: 0.16in 0 0.07in 0;
+}
+h2 {
+  font-family: var(--zn-display);
+  font-size: 13pt;
+  margin: 0.14in 0 0.06in 0;
+}
+
+p { margin-bottom: 0.09in; }
+
+/* checkbox steps — the zine's signature */
+.zn-step {
+  margin-bottom: 0.09in;
+  padding-left: 0.22in;
+  text-indent: -0.22in;
+}
+.zn-step::before { content: "\2750\00a0 "; font-size: 10.5pt; }
+.zn-step strong { font-weight: 700; }
+
+/* centered bold URL / command lines */
+.zn-url {
+  text-align: center;
+  font-weight: 700;
+  margin: 0.07in 0 0.1in 0;
+  font-size: 9.5pt;
+  word-break: break-all;
+}
+.zn-cmd {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 8.5pt;
+  background: var(--mp-card-bg);
+  border: 1px solid var(--mp-track);
+  padding: 0.05in 0.08in;
+  margin: 0.06in 0 0.1in 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* bordered figures */
+.zn-img { text-align: center; margin: 0.1in 0; break-inside: avoid; }
+.zn-img img { max-width: 80%; border: 1px solid var(--mp-rule); padding: 0.02in; background: var(--mp-paper); }
+.zn-img .cap { font-size: 7.5pt; color: var(--mp-muted); margin-top: 0.03in; }
+
+/* warnings */
+.zn-warn {
+  border: 1.5px solid var(--mp-alert);
+  background: var(--mp-alert-bg);
+  padding: 0.06in 0.09in;
+  margin: 0.1in 0;
+  font-size: 9pt;
+  break-inside: avoid;
+}
+.zn-warn strong { color: var(--mp-alert); font-weight: 700; }
+
+.not-configured { margin: 0.08in 0; padding: 0.06in 0.08in; border: 1px dashed var(--mp-muted); font-size: 8.5pt; color: var(--mp-muted); }
+
+/* charts work here too */
+.mp-chart { margin: 0.1in 0; break-inside: avoid; }
+.mp-chart-title { font-size: 7.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.05em; color: var(--mp-muted); margin-bottom: 0.03in; }
+.mp-chart svg { display: block; width: 100%; height: auto; }
+.mp-stats { display: flex; gap: 0.08in; margin: 0.08in 0; flex-wrap: wrap; }
+.mp-stat { flex: 1 1 0; min-width: 0.9in; border-top: 2px solid var(--mp-rule); padding: 0.04in 0.02in 0 0.02in; }
+.mp-stat-value { font-size: 13pt; font-weight: 700; color: var(--mp-chart-ink); }
+.mp-stat-delta { font-size: 6.5pt; color: var(--mp-muted); }
+.mp-stat-label { font-size: 6pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--mp-muted); margin-top: 0.015in; }
+
+table.data { width: 100%; border-collapse: collapse; margin: 0.06in 0; font-size: 8.5pt; }
+table.data th { text-align: left; font-size: 7pt; text-transform: uppercase; color: var(--mp-muted); border-bottom: 1px solid var(--mp-rule); padding: 0.02in 0.04in 0.02in 0; }
+table.data td { padding: 0.02in 0.04in 0.02in 0; border-bottom: 1px solid var(--mp-track); vertical-align: top; }
+
+ul, ol { margin: 0.02in 0 0.08in 0.22in; }
+li { line-height: 1.45; margin-bottom: 0.025in; }
+a { color: var(--mp-ink); font-weight: 700; text-decoration: none; }
+.page-break { page-break-before: always; }

--- a/src/morning_paper/styles.py
+++ b/src/morning_paper/styles.py
@@ -40,6 +40,16 @@ STYLES: dict[str, StylePack] = {
         css_resource="styles/ops-card.css",
         description="Boxed reference one-pager: scripts, checklists, cheat sheets.",
     ),
+    "magazine": StylePack(
+        name="magazine",
+        css_resource="styles/magazine.css",
+        description="Long-read essay page: serif body, pull quotes, wide margins.",
+    ),
+    "zine": StylePack(
+        name="zine",
+        css_resource="styles/zine.css",
+        description="Pocket how-to guide: half-letter, marker display type, checkbox steps.",
+    ),
 }
 
 PALETTES: dict[str, Palette] = {


### PR DESCRIPTION
Two new genres for the render seam, both studied from real artifacts:

- **`magazine`** — long-read essay page, modeled on every.to's article typography (Signifier's own Palatino/Georgia fallback chain, so nothing licensed ships). Kicker / title / dek / byline header, pull quotes, raised-cap lede, end mark. WeasyPrint asserts on floated `::first-letter`, so drop caps render as raised caps (documented in the stylesheet).
- **`zine`** — pocket how-to guide, modeled on the Iffy Books Meshtastic zine (CC0). Half-letter page, marker display type, ❏ checkbox steps, command blocks, warning boxes. Print 2-up on Letter and fold.

Both consume the shared palette tokens (mono/color) and chart directives. Tests 15/15. Version 0.2.1.

(Replaces #6, which conflicted after the #5 squash-merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)