### PR TITLE
Editor primitives, editorial style pack, Claude Code plugin (0.3.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "morning-paper",
+  "version": "0.3.0",
+  "description": "Your personal newsroom: a daily printed paper composed by your agent from your sources, with preferences you own as files.",
+  "author": { "name": "Devon Meadows", "url": "https://github.com/dmthepm" },
+  "homepage": "https://github.com/dmthepm/morning-paper",
+  "license": "MIT",
+  "keywords": ["newspaper", "print", "daily-brief", "newsroom", "pdf"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-11
+
+### Added
+- Agent-facing staging verbs: `stage <url|file>` (queues material for tomorrow's paper, answers with a page estimate), `queue` (staged items vs `page_budget`), `estimate <file.md>` (page count, nothing written) — all JSON; `add`/`status` are aliases
+- `editorial` style pack — the unified paper system (one document, continuous folios on the outside duplex corner, running section heads, separators instead of forced page breaks, CSS-drawn marks instead of fallback glyphs, one-red-moment color discipline)
+- Claude Code plugin: `setup` (cold-start interview -> config + private newsroom repo + morning routine) and `edition` (the daily editor pass) skills
+- `page_budget` config key; README "For Agents" quickstart
+
+
 ## [0.2.1] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ artifacts, and gives you a newspaper you can actually print and read.
 
 No database. No Docker. No SaaS requirement.
 
+## For Agents (read this first if you are one)
+
+Your human wants a daily printed paper. You can give them one:
+
+1. Install: `pip install "morning-paper[pretty]"` then `morning-paper doctor`.
+2. If this repo is installed as a Claude Code plugin, run the `setup` skill —
+   it interviews the reader, creates their private newsroom repo (preferences
+   as files: the owned algorithm), and wires a morning routine. The `edition`
+   skill composes and renders each day's paper.
+3. The CLI speaks JSON. The verbs you need:
+   - `morning-paper stage <url>` -> stages it for tomorrow and answers with a
+     page estimate ("that adds ~5 pages")
+   - `morning-paper queue` -> what's staged vs the page budget
+   - `morning-paper estimate <file.md>` -> page count, nothing written
+   - `morning-paper render <file.md> --style <s> --palette <p>` -> the PDF
+4. Composition contract, class vocabulary, and chart directives: `docs/composing.md`.
+5. Honesty rule: a section with no data says "not configured" — never fabricate.
+
 ## What It Does
 
 - Builds a daily paper from Hacker News and RSS feeds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.2.1"
+version = "0.3.0"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/edition/SKILL.md
+++ b/skills/edition/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: edition
+description: >
+  Compose, render, and deliver today's Morning Paper edition. Use every
+  morning (scheduled routine or manual), or when the user says "build my
+  paper", "today's edition", "morning brief". Requires setup to have run.
+---
+
+# Morning Paper — The Edition
+
+You are the editor. Collectors and the CLI are deterministic; the judgment is
+yours. The binding lesson from this project's history: the agent composes
+against a good stylesheet; code renders it faithfully; code never writes the
+paper.
+
+## The pass
+
+1. **Collect.** Run the user's collectors (newsroom `collectors/`, or the
+   engine's `morning-paper build` for HN/RSS). Check the staged queue:
+   `morning-paper queue` — anything staged via `stage` belongs in today's
+   paper (a human or another agent put it there on purpose).
+2. **Read the newsroom.** `specs/*` (section contracts) and `preferences/*`
+   (reading weights, style notes). These outrank your taste.
+3. **Compose** one markdown document (raw HTML allowed; see the engine's
+   docs/composing.md for the class vocabulary and `mp-bars`/`mp-spark`/
+   `mp-stats` chart directives):
+   - A front synthesis: the single thing that matters today, as a judgment.
+   - The operator/work sections their specs define.
+   - Full reads from the staged queue and configured feeds — entire articles,
+     typeset; not summaries.
+   - Every claim traceable to collected data. A missing source prints
+     "not configured". NEVER fabricate a number.
+4. **Budget.** `morning-paper estimate draft.md` — fit `page_budget` ±2 by
+   cutting the weakest material, never by shrinking type.
+5. **Render.** `morning-paper render draft.md --style <their style> --palette
+   <their palette> --date <today> --slug edition`.
+6. **QA.** Rasterize page 1 + one inner page (`pdftoppm -png -r 60`) and look:
+   no overflow, no missing glyphs (tofu), footers present.
+7. **Deliver.** Their saved print command (duplex flag and all), or just hand
+   back the PDF path. Archive markdown + html into `editions/<date>/`.
+
+## Voice
+
+Lead with judgment, carry numbers in prose, no filler. Stale items get
+flagged, not repeated verbatim. If yesterday's open questions are still
+unanswered, say so once, plainly — the paper is allowed to notice.
+
+## Return path
+
+If the user dictates or replies with reactions ("more like this", "kill
+section X", "print <url> tomorrow"): update `preferences/`, and `morning-paper
+stage <url>` anything they asked to read. Tomorrow's editor reads what you
+wrote today.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: setup
+description: >
+  Morning Paper cold-start: install the engine, interview the reader, create
+  their private newsroom repo, and wire the morning routine. Use on first run,
+  when ~/.config/morning-paper/config.yaml is missing, or when the user says
+  "set up my morning paper", "onboard me", "configure morning paper".
+---
+
+# Morning Paper — Setup
+
+You are setting up a personal newsroom. The outcome: a config, a private
+"newsroom" repo of preferences the user owns, and (optionally) a scheduled
+morning routine. Degrade honestly at every step — a paper with two sources
+beats a broken setup with ten.
+
+## 1. Engine
+
+```bash
+pip install "morning-paper[pretty]" || pipx install "morning-paper[pretty]"
+morning-paper doctor   # must report: typewriter ready (macOS may need: brew install pango gdk-pixbuf)
+morning-paper init
+```
+
+## 2. The interview (conversational, not a form)
+
+Ask in 2-3 messages, not twenty. Capture:
+- **Who they are / what they run** — work, projects, what "useful every morning" means to them. This seeds `profile` in config.yaml and the editor's voice.
+- **Sources** — RSS feeds they read, newsletters with full-text feeds (paid feed
+  URLs are credentials: store in `~/.config/morning-paper/env.sh`, never in a
+  repo), Hacker News yes/no.
+- **Shape** — `page_budget` (suggest 12-20), how many full reads per edition,
+  style (`morning-paper styles` lists them; `editorial` is the default
+  recommendation), palette (`color` for inkjets, `mono` for laser).
+- **Printer** — CUPS name (`lpstat -p`), duplex capable? Save the print
+  command in the newsroom README.
+
+Write their answers into `~/.config/morning-paper/config.yaml`.
+
+## 3. Optional unlocks (state the leverage, let them skip)
+
+- **Apify key** (`APIFY_TOKEN`): X/Twitter radar via tweet-scraper actors,
+  about $0.02/day at 40 tweets. Worth it if their work has a market lane.
+- **last30days plugin**: Reddit/HN/Polymarket deep research for a weekly
+  trends page.
+- **gh CLI**: a "shipped while you slept" section from their repos.
+Each missing unlock = a section that prints "not configured", never fake data.
+
+## 4. The newsroom repo (the owned algorithm)
+
+Create a PRIVATE repo (suggest `<user>/newsroom`) with:
+```
+specs/        # one file per section: source, page budget, voice, failure mode
+preferences/  # reading-weights.md, style notes — the editor reads these daily
+editions/     # date-keyed archives (gitignore *.pdf)
+collectors/   # any custom source scripts
+```
+Explain the point in one line: *your feed has an algorithm you can't see;
+your paper's algorithm is files you can read and edit.*
+
+## 5. The morning routine
+
+Offer to schedule it (Claude scheduled tasks / cron): every morning run the
+`edition` skill of this plugin. If they prefer manual, the command is just
+invoking `/morning-paper:edition`.
+
+## 6. First edition, now
+
+Run the edition skill once end-to-end while they watch. Print it if the
+printer is ready. Hand them the paper. Done is a physical object.

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/src/morning_paper/cli.py
+++ b/src/morning_paper/cli.py
@@ -20,7 +20,7 @@ from .styles import PALETTES, STYLES, StyleError
 DOCS_URL = "https://github.com/dmthepm/morning-paper"
 ROADMAP_URL = f"{DOCS_URL}/blob/main/ROADMAP.md"
 PYPI_JSON_URL = "https://pypi.org/pypi/morning-paper/json"
-ROADMAP_COMMANDS = {"add", "status", "remove", "list"}
+ROADMAP_COMMANDS = {"remove", "list"}
 HELP_TEXT = f"""Morning Paper — your morning newspaper, built from your own sources.
 
 Commands:
@@ -28,13 +28,15 @@ Commands:
   build             Build today's paper from configured sources
   print <url>       Print a single article right now
   render <file.md>  Typeset any markdown file through a style pack
+  stage <url|file>  Queue material for tomorrow's paper (returns a page estimate)
+  queue             Show what's staged vs the page budget (JSON)
+  estimate <file>   Page count for a markdown file, nothing written
   styles            List available styles and palettes
   doctor            Check config, dependencies, and renderer status
   --version         Show installed version
 
-Coming soon:
-  add <url|file>    Add content to tomorrow's paper
-  status            Show what's staged and estimated page count
+Agents: every command prints JSON. `stage` + `queue` are the seam for
+"add this to tomorrow's brief" workflows. See docs/composing.md.
 
 Config: {DEFAULT_CONFIG_PATH}
 Docs:   {DOCS_URL}
@@ -388,6 +390,153 @@ def render_command(args: list[str]) -> int:
     return 0
 
 
+def _parse_common(args: list[str], usage: str) -> tuple[Path, str | None, list[str]] | int:
+    config_path = DEFAULT_CONFIG_PATH
+    date = None
+    rest: list[str] = []
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg in {"-h", "--help"}:
+            print(usage)
+            return 0
+        if arg == "--config" and index + 1 < len(args):
+            config_path = Path(args[index + 1]).expanduser().resolve()
+            index += 2
+            continue
+        if arg == "--date" and index + 1 < len(args):
+            date = args[index + 1]
+            index += 2
+            continue
+        rest.append(arg)
+        index += 1
+    return config_path, date, rest
+
+
+def stage_command(args: list[str]) -> int:
+    from .staging import default_edition_date, stage_markdown
+
+    usage = "usage: morning-paper stage <url|file.md> [--title T] [--date YYYY-MM-DD] [--config PATH]"
+    title_override = None
+    if "--title" in args:
+        i = args.index("--title")
+        if i + 1 < len(args):
+            title_override = args[i + 1]
+            args = args[:i] + args[i + 2 :]
+    parsed = _parse_common(args, usage)
+    if isinstance(parsed, int):
+        return parsed
+    config_path, date, rest = parsed
+    if len(rest) != 1:
+        print(usage, file=sys.stderr)
+        return 2
+    target = rest[0]
+    try:
+        config, _ = _load_print_config(config_path)
+    except ConfigError as exc:
+        print(f"invalid config: {exc}", file=sys.stderr)
+        return 1
+    date_str = date or default_edition_date(config)
+    if target.startswith("http://") or target.startswith("https://"):
+        try:
+            article = fetch_article(target, extractor_name=config.article_extractor)
+        except ArticleExtractionError as exc:
+            print(json.dumps({"staged": False, "error": str(exc)}, indent=2))
+            return 1
+        markdown = render_article_markdown(
+            config,
+            [article],
+            date_str=date_str,
+            images_dir=config.outputs.directory / "staging" / date_str / "_images",
+        )
+        item = stage_markdown(
+            config, markdown, date_str=date_str, kind="url", source=target,
+            title=title_override or article.title,
+        )
+    else:
+        source = Path(target).expanduser()
+        if not source.is_file():
+            print(f"no such file: {source}", file=sys.stderr)
+            return 1
+        item = stage_markdown(
+            config, source.read_text(encoding="utf-8"), date_str=date_str,
+            kind="file", source=str(source), title=title_override or source.stem,
+        )
+    from dataclasses import asdict
+
+    payload = {"staged": True, "edition_date": date_str, **asdict(item)}
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def queue_command(args: list[str]) -> int:
+    from .staging import default_edition_date, queue_status
+
+    usage = "usage: morning-paper queue [--date YYYY-MM-DD] [--config PATH]"
+    parsed = _parse_common(args, usage)
+    if isinstance(parsed, int):
+        return parsed
+    config_path, date, rest = parsed
+    if rest:
+        print(usage, file=sys.stderr)
+        return 2
+    try:
+        config, _ = _load_print_config(config_path)
+    except ConfigError as exc:
+        print(f"invalid config: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(queue_status(config, date or default_edition_date(config)), indent=2))
+    return 0
+
+
+def estimate_command(args: list[str]) -> int:
+    from .renderers import count_pages
+
+    usage = "usage: morning-paper estimate <file.md> [--style NAME] [--palette NAME] [--config PATH]"
+    style = palette = None
+    for flag in ("--style", "--palette"):
+        if flag in args:
+            i = args.index(flag)
+            if i + 1 < len(args):
+                value = args[i + 1]
+                args = args[:i] + args[i + 2 :]
+                if flag == "--style":
+                    style = value
+                else:
+                    palette = value
+    parsed = _parse_common(args, usage)
+    if isinstance(parsed, int):
+        return parsed
+    config_path, _date, rest = parsed
+    if len(rest) != 1:
+        print(usage, file=sys.stderr)
+        return 2
+    source = Path(rest[0]).expanduser()
+    if not source.is_file():
+        print(f"no such file: {source}", file=sys.stderr)
+        return 1
+    try:
+        config, _ = _load_print_config(config_path)
+    except ConfigError as exc:
+        print(f"invalid config: {exc}", file=sys.stderr)
+        return 1
+    markdown = source.read_text(encoding="utf-8")
+    try:
+        pages = count_pages(
+            markdown,
+            style=style or config.outputs.style,
+            palette=palette or config.outputs.palette,
+        )
+    except StyleError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"estimate requires the pretty print stack: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"file": str(source), "words": len(markdown.split()), "est_pages": pages}, indent=2))
+    return 0
+
+
 def print_help() -> int:
     print(HELP_TEXT.rstrip())
     return 0
@@ -413,6 +562,12 @@ def main(argv: list[str] | None = None) -> int:
         return print_command(extra)
     if command == "render":
         return render_command(extra)
+    if command in {"stage", "add"}:
+        return stage_command(extra)
+    if command in {"queue", "status"}:
+        return queue_command(extra)
+    if command == "estimate":
+        return estimate_command(extra)
     if command == "styles":
         return styles_command()
     if command == "doctor":

--- a/src/morning_paper/config.py
+++ b/src/morning_paper/config.py
@@ -54,6 +54,7 @@ class MorningPaperConfig:
     timezone: str = "America/Los_Angeles"
     profile: str = ""
     article_extractor: str = "jina"
+    page_budget: int = 20
     sources: SourcesConfig = field(default_factory=SourcesConfig)
     outputs: OutputsConfig = field(default_factory=OutputsConfig)
 
@@ -132,11 +133,15 @@ def load_config(path: Path) -> MorningPaperConfig:
         for feed in (sources.get("rss") or [])
         if feed.get("name") and feed.get("url")
     ]
+    page_budget = int(data.get("page_budget", 20))
+    if not 1 <= page_budget <= 200:
+        raise ConfigError("page_budget must be between 1 and 200")
     return MorningPaperConfig(
         name=str(data.get("name", "Morning Paper")),
         timezone=_validate_timezone(str(data.get("timezone", "America/Los_Angeles"))),
         profile=str(data.get("profile", "")).strip(),
         article_extractor=_validate_article_extractor(str(data.get("article_extractor", "jina"))),
+        page_budget=page_budget,
         sources=SourcesConfig(
             hacker_news=HackerNewsConfig(
                 enabled=bool(hn.get("enabled", True)),
@@ -166,6 +171,8 @@ profile: |
   Add a short note about who this paper is for and what should matter most.
   Example: early-stage AI tools, operator software, media, and founder signal.
 article_extractor: jina
+# target length for a full edition; `morning-paper queue` reports against this
+page_budget: 20
 
 sources:
   hacker_news:

--- a/src/morning_paper/renderers.py
+++ b/src/morning_paper/renderers.py
@@ -416,6 +416,19 @@ def _render_typewriter_pdf(markdown: str, *, output_path: Path, style: str = "ty
     html_cls(string=html_doc, base_url=str(output_path.parent)).write_pdf(str(output_path))
 
 
+def count_pages(markdown: str, *, style: str = "typewriter", palette: str = "mono") -> int:
+    """Lay the document out without writing anything; return its page count.
+
+    The agent-facing `estimate`/`stage` verbs use this to answer "how many
+    pages would this add?" before composition time.
+    """
+    html_cls, error = _load_weasyprint()
+    if html_cls is None:
+        raise RuntimeError(error or "WeasyPrint unavailable")
+    html_doc = _render_html_from_markdown(markdown, style=style, palette=palette)
+    return len(html_cls(string=html_doc).render().pages)
+
+
 def _render_markdown_text_pdf(config: MorningPaperConfig, markdown: str, *, date_str: str, output_path: Path) -> None:
     _meta, body = _split_frontmatter(markdown)
     rendered_body = _MARKDOWN.render(body)

--- a/src/morning_paper/resources/styles/editorial.css
+++ b/src/morning_paper/resources/styles/editorial.css
@@ -1,0 +1,197 @@
+/* Style pack: editorial — THE unified Morning Paper system.
+ * One stylesheet for the whole edition: operator front + reading edition,
+ * per docs/design-consolidation-spec (2026-06-11). Black-ink-first; color is
+ * annotation, never decoration. No forced page breaks — separators flow.
+ * Glyph policy: nothing depends on font fallback; marks are CSS-drawn
+ * (.cb checkbox, .endmark) or written (.flag text tags). Symbol whitelist:
+ * Latin-1 + typographic basics (§ · – — quotes …).
+ * Footer strings: <span class="mp-footer-date">No. 3 · Friday 12 June 2026</span>
+ *                 <span class="mp-footer-name">MORNING PAPER</span>
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:ital,wght@0,400;0,700;1,400&display=swap');
+
+:root {
+  --ed-serif: 'Palatino', 'Palatino Linotype', 'Book Antiqua', Georgia, 'Times New Roman', serif;
+  --ed-sans: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --ed-mono: 'Courier Prime', 'Courier New', Courier, monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+/* ---- page geometry: Letter, duplex-mirrored, folio outside ---- */
+@page {
+  size: Letter;
+  margin: 0.8in 0.9in 0.9in 0.9in;
+  @bottom-center { content: string(mp-name); font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-weight: 700; font-size: 7pt; letter-spacing: 0.14em; color: #888888; }
+}
+@page :right {
+  margin-left: 1.0in; margin-right: 0.8in;
+  @bottom-right { content: counter(page); font-family: 'Palatino', Georgia, serif; font-size: 9pt; color: #555555; }
+  @bottom-left  { content: string(mp-date); font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 7pt; color: #888888; }
+  @top-right { content: string(mp-section, first); font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-weight: 700; font-size: 6.5pt; letter-spacing: 0.14em; color: #999999; }
+}
+@page :left {
+  margin-left: 0.8in; margin-right: 1.0in;
+  @bottom-left  { content: counter(page); font-family: 'Palatino', Georgia, serif; font-size: 9pt; color: #555555; }
+  @bottom-right { content: string(mp-date); font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 7pt; color: #888888; }
+  @top-left { content: string(mp-section, first); font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-weight: 700; font-size: 6.5pt; letter-spacing: 0.14em; color: #999999; }
+}
+@page :first {
+  @top-right { content: none; }
+  @top-left { content: none; }
+}
+
+.mp-footer-date, .mp-footer-name {
+  display: block; height: 0; overflow: hidden;
+  font-size: 0; line-height: 0; visibility: hidden;
+}
+.mp-footer-date { string-set: mp-date content(); }
+.mp-footer-name { string-set: mp-name content(); }
+
+body {
+  font-family: var(--ed-serif);
+  font-size: 10.5pt;
+  line-height: 1.55;
+  color: var(--mp-ink);
+  background: var(--mp-paper);
+}
+p { margin-bottom: 0.11in; orphans: 3; widows: 3; }
+code { font-family: var(--ed-mono); font-size: 0.92em; }
+a { color: var(--mp-chart-ink); text-decoration: none; }
+table.data a, .dept-list a { color: var(--mp-ink); }
+em { font-style: italic; }
+ul, ol { margin: 0.03in 0 0.1in 0.25in; }
+li { line-height: 1.5; margin-bottom: 0.03in; }
+
+/* ---- masthead ---- */
+.masthead { text-align: center; margin-bottom: 0.14in; }
+.masthead-title { font-family: var(--ed-serif); font-size: 30pt; font-weight: 700; letter-spacing: 0.01em; line-height: 1; }
+.dateline { font-family: var(--ed-sans); font-size: 7.5pt; letter-spacing: 0.12em; text-transform: uppercase; color: var(--mp-muted); margin-top: 0.05in; }
+.oxford { border-top: 2pt solid var(--mp-rule); border-bottom: 0.5pt solid var(--mp-rule); height: 2.5pt; margin-top: 0.08in; }
+
+/* ---- front strip ---- */
+.strip { display: flex; border-bottom: 0.5pt solid var(--mp-rule); margin-bottom: 0.16in; }
+.strip-item { flex: 1 1 0; padding: 0.05in 0.12in; border-left: 0.5pt solid var(--mp-track); min-width: 0; }
+.strip-item:first-child { border-left: none; padding-left: 0; }
+.strip-label { font-family: var(--ed-sans); font-size: 6.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mp-muted); }
+.strip-value { font-family: var(--ed-serif); font-size: 8.5pt; line-height: 1.35; margin-top: 0.02in; }
+.strip-value.alert { font-weight: 700; color: var(--mp-alert); }
+
+/* ---- article header family ---- */
+.article-head { break-inside: avoid; }
+.mg-kicker, .dept-kicker {
+  font-family: var(--ed-sans); font-size: 8pt; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.16em; color: var(--mp-ink);
+  margin-bottom: 0.1in; string-set: mp-section content();
+}
+.mg-title { font-family: var(--ed-serif); font-size: 23pt; font-weight: 700; line-height: 1.15; letter-spacing: -0.01em; margin-bottom: 0.12in; }
+.dept-title { font-family: var(--ed-serif); font-size: 15pt; font-weight: 700; line-height: 1.2; margin-bottom: 0.08in; }
+.mg-dek { font-family: var(--ed-serif); font-style: italic; font-size: 12pt; line-height: 1.4; color: var(--mp-muted); margin-bottom: 0.14in; }
+.mg-byline {
+  font-family: var(--ed-sans); font-size: 8pt; text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--mp-muted); padding: 0.06in 0; border-top: 1px solid var(--mp-rule);
+  border-bottom: 1px solid var(--mp-rule); margin-bottom: 0.2in;
+}
+.mg-byline strong { color: var(--mp-ink); font-weight: 700; }
+.mg-lede::first-letter { font-size: 15pt; font-weight: 700; }
+h1, h2 { font-family: var(--ed-sans); font-size: 11pt; font-weight: 700; letter-spacing: 0.02em; margin: 0.2in 0 0.08in 0; }
+
+/* ---- separators: flow, never force pages ---- */
+.sep {
+  text-align: center; font-family: var(--ed-serif); font-size: 11pt; color: var(--mp-muted);
+  letter-spacing: 0.6em; padding-left: 0.6em;
+  margin: 0.26in 0 0.22in 0; break-after: avoid;
+}
+.dept-rule { border-top: 0.5pt solid var(--mp-rule); margin: 0.18in 0 0.12in 0; }
+.edition-divider { margin: 0.3in 0 0.25in 0; break-after: avoid; }
+.edition-divider .oxford { margin: 0; }
+.edition-divider-label {
+  text-align: center; font-family: var(--ed-sans); font-size: 8pt; font-weight: 700;
+  letter-spacing: 0.2em; text-transform: uppercase; padding: 0.05in 0;
+}
+
+/* ---- the queue: ruled agenda rows ---- */
+.q-row { display: flex; gap: 0.1in; align-items: baseline; padding: 0.06in 0 0.07in 0; border-bottom: 0.5pt solid var(--mp-track); break-inside: avoid; }
+.q-row:first-of-type { border-top: 0.5pt solid var(--mp-rule); }
+.cb { display: inline-block; width: 8pt; height: 8pt; border: 0.9pt solid var(--mp-ink); vertical-align: -0.8pt; margin-right: 0.06in; }
+.q-body { flex: 1 1 auto; min-width: 0; }
+.q-t { font-family: var(--ed-serif); font-size: 10.5pt; font-weight: 700; line-height: 1.3; }
+.q-d { font-family: var(--ed-serif); font-size: 9.5pt; line-height: 1.45; margin-top: 0.02in; }
+.q-u { font-family: var(--ed-sans); font-size: 7pt; color: var(--mp-muted); margin-top: 0.025in; }
+.q-u strong { font-weight: 700; }
+.q-min { font-family: var(--ed-sans); font-size: 7.5pt; font-weight: 700; color: var(--mp-muted); white-space: nowrap; text-transform: uppercase; }
+
+/* ---- flags: written, outlined, never filled ---- */
+.flag {
+  display: inline-block; font-family: var(--ed-sans); font-size: 6.5pt; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.08em; padding: 0.5pt 3pt;
+  border: 0.5pt solid currentColor; vertical-align: 0.5pt;
+}
+.flag-alert { color: var(--mp-alert); }
+.flag-info { color: var(--mp-muted); }
+.flag-positive { color: var(--mp-positive); }
+td .overdue, .overdue { color: var(--mp-alert); font-weight: 700; }
+
+/* ---- stats: openwork figures, ink numerals ---- */
+.mp-stats { display: flex; gap: 0.12in; margin: 0.1in 0; flex-wrap: wrap; }
+.mp-stat { flex: 1 1 0; min-width: 1.1in; border-top: 2pt solid var(--mp-rule); padding: 0.06in 0.02in 0 0.02in; break-inside: avoid; }
+.mp-stat-value { font-family: var(--ed-serif); font-size: 17pt; font-weight: 700; line-height: 1.05; color: var(--mp-ink); }
+.mp-stat-delta { font-family: var(--ed-sans); font-size: 7.5pt; color: var(--mp-muted); margin-top: 0.015in; }
+.mp-stat-delta.alert { color: var(--mp-alert); font-weight: 700; }
+.mp-stat-label { font-family: var(--ed-sans); font-size: 6.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mp-muted); margin-top: 0.02in; }
+
+/* ---- tables: one definition ---- */
+table.data { width: 100%; border-collapse: collapse; margin: 0.08in 0; font-family: var(--ed-sans); font-size: 8.5pt; }
+table.data th { text-align: left; font-size: 6.5pt; text-transform: uppercase; letter-spacing: 0.06em; color: var(--mp-muted); border-bottom: 0.5pt solid var(--mp-rule); padding: 0.02in 0.08in 0.02in 0; }
+table.data td { padding: 0.03in 0.08in 0.03in 0; border-bottom: 0.5pt solid var(--mp-track); vertical-align: top; line-height: 1.4; }
+table.data tr { break-inside: avoid; }
+table.data td.num { text-align: right; }
+table.data td.lead { font-family: var(--ed-serif); font-weight: 700; }
+
+/* ---- pull quote ---- */
+.mg-pull {
+  font-family: var(--ed-serif); font-style: italic; font-size: 14.5pt; line-height: 1.4;
+  color: var(--mp-ink); border-left: 2.5pt solid var(--mp-rule);
+  padding: 0.04in 0 0.04in 0.18in; margin: 0.18in 0.1in 0.18in 0; break-inside: avoid;
+}
+.mg-pull-attr { display: block; font-family: var(--ed-sans); font-style: normal; font-size: 7.5pt; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mp-muted); margin-top: 0.05in; }
+blockquote { font-style: italic; border-left: 2px solid var(--mp-track); padding-left: 0.15in; margin: 0.1in 0 0.12in 0.05in; }
+
+/* ---- THE MOVE / YOUR MOVE: the only cream in the paper ---- */
+.move {
+  background: var(--mp-card-bg); border-top: 1.5pt solid var(--mp-rule);
+  padding: 0.09in 0.12in; margin: 0.16in 0 0.04in 0;
+  font-family: var(--ed-serif); font-size: 9.5pt; line-height: 1.45;
+  break-inside: avoid; break-before: avoid;
+}
+.move-label { display: block; font-family: var(--ed-sans); font-size: 7pt; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; margin-bottom: 0.035in; }
+.dictation {
+  border: 1pt solid var(--mp-rule); background: var(--mp-card-bg);
+  padding: 0.09in 0.12in; margin: 0.14in 0;
+  font-family: var(--ed-serif); font-style: italic; font-size: 10.5pt; line-height: 1.5;
+  break-inside: avoid;
+}
+.dictation .move-label { font-style: normal; }
+
+/* ---- action required: the budgeted red block ---- */
+.action-required { border-left: 2.5pt solid var(--mp-alert); padding: 0.06in 0 0.06in 0.14in; margin: 0.16in 0; break-inside: avoid; }
+.action-required .ar-head { font-family: var(--ed-sans); font-size: 7pt; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase; color: var(--mp-alert); margin-bottom: 0.05in; }
+.ar-item { font-family: var(--ed-serif); font-size: 9.5pt; line-height: 1.45; margin-bottom: 0.04in; }
+.ar-item strong { font-weight: 700; }
+
+/* ---- department prose lists ---- */
+.dept-list p { font-size: 9.5pt; line-height: 1.45; margin-bottom: 0.06in; }
+.dept-list strong { font-weight: 700; }
+
+/* ---- charts (SVG presentation attrs inline per charts.py) ---- */
+.mp-chart { margin: 0.14in 0; break-inside: avoid; }
+.mp-chart-title { font-family: var(--ed-sans); font-size: 7.5pt; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: var(--mp-muted); margin-bottom: 0.04in; }
+.mp-chart svg { display: block; width: 100%; height: auto; }
+
+/* ---- honest degradation ---- */
+.not-configured { margin: 0.1in 0; padding: 0.07in 0.1in; border: 1px dashed var(--mp-muted); font-family: var(--ed-sans); font-size: 8.5pt; color: var(--mp-muted); line-height: 1.45; }
+.mg-note { font-family: var(--ed-sans); font-size: 8.5pt; line-height: 1.5; color: var(--mp-muted); background: none; padding: 0; margin: 0.1in 0; }
+
+/* ---- end mark: drawn, not a glyph ---- */
+.endmark { display: inline-block; width: 5.5pt; height: 5.5pt; background: var(--mp-ink); margin-left: 0.05in; vertical-align: -0.2pt; }

--- a/src/morning_paper/staging.py
+++ b/src/morning_paper/staging.py
@@ -1,0 +1,108 @@
+"""Tomorrow's-brief staging: the queue any agent can feed.
+
+`morning-paper stage <url|file>` drops material into a date-keyed staging
+directory and answers with an honest page estimate, so an agent anywhere can
+reply "that adds ~5 pages; it's in the queue for the editor." The editor's
+composition pass reads the same queue. File-first, no database.
+
+Layout:
+    {outputs.directory}/staging/{date}/queue.json     — item metadata
+    {outputs.directory}/staging/{date}/{slug}.md      — staged markdown
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from .config import MorningPaperConfig
+from .renderers import _safe_filename, count_pages
+
+
+@dataclass(slots=True)
+class StagedItem:
+    slug: str
+    kind: str            # url | file | note
+    source: str          # the URL or original path
+    title: str
+    words: int
+    est_pages: int
+    staged_at: str
+
+
+def staging_dir(config: MorningPaperConfig, date_str: str) -> Path:
+    return config.outputs.directory / "staging" / date_str
+
+
+def default_edition_date(config: MorningPaperConfig) -> str:
+    """Material staged during the day is for TOMORROW's paper."""
+    now = datetime.now(ZoneInfo(config.timezone))
+    return (now.date() + timedelta(days=1)).isoformat()
+
+
+def _load_queue(path: Path) -> list[dict]:
+    queue_file = path / "queue.json"
+    if queue_file.exists():
+        return json.loads(queue_file.read_text(encoding="utf-8"))
+    return []
+
+
+def _save_queue(path: Path, items: list[dict]) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "queue.json").write_text(json.dumps(items, indent=2), encoding="utf-8")
+
+
+def stage_markdown(
+    config: MorningPaperConfig,
+    markdown: str,
+    *,
+    date_str: str,
+    kind: str,
+    source: str,
+    title: str,
+) -> StagedItem:
+    sdir = staging_dir(config, date_str)
+    slug = _safe_filename(title)[:48] or "staged"
+    queue = _load_queue(sdir)
+    existing = {item["slug"] for item in queue}
+    base, n = slug, 2
+    while slug in existing:
+        slug, n = f"{base}-{n}", n + 1
+    try:
+        pages = count_pages(markdown, style=config.outputs.style, palette=config.outputs.palette)
+    except Exception:
+        # estimation must never block staging; fall back to a words heuristic
+        pages = max(1, round(len(markdown.split()) / 550))
+    sdir.mkdir(parents=True, exist_ok=True)
+    (sdir / f"{slug}.md").write_text(markdown, encoding="utf-8")
+    item = StagedItem(
+        slug=slug,
+        kind=kind,
+        source=source,
+        title=title,
+        words=len(markdown.split()),
+        est_pages=pages,
+        staged_at=datetime.now(ZoneInfo(config.timezone)).isoformat(timespec="seconds"),
+    )
+    queue.append(asdict(item))
+    _save_queue(sdir, queue)
+    return item
+
+
+def queue_status(config: MorningPaperConfig, date_str: str) -> dict:
+    sdir = staging_dir(config, date_str)
+    items = _load_queue(sdir)
+    total = sum(int(item.get("est_pages", 0)) for item in items)
+    budget = config.page_budget
+    return {
+        "date": date_str,
+        "items": items,
+        "count": len(items),
+        "est_pages_total": total,
+        "page_budget": budget,
+        "budget_remaining": (budget - total) if budget else None,
+        "staging_dir": str(sdir),
+    }

--- a/src/morning_paper/styles.py
+++ b/src/morning_paper/styles.py
@@ -25,6 +25,11 @@ class Palette:
 
 
 STYLES: dict[str, StylePack] = {
+    "editorial": StylePack(
+        name="editorial",
+        css_resource="styles/editorial.css",
+        description="THE unified paper: serif editorial system for operator and reading content; no forced breaks, drawn marks, restrained color.",
+    ),
     "typewriter": StylePack(
         name="typewriter",
         css_resource="styles/typewriter.css",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -404,7 +404,7 @@ class CliSurfaceTest(unittest.TestCase):
         self.assertIn("Morning Paper", output)
         self.assertIn("Commands:", output)
         self.assertIn("print <url>", output)
-        self.assertIn("Coming soon:", output)
+        self.assertIn("stage <url|file>", output)
         self.assertIn("https://github.com/dmthepm/morning-paper", output)
 
     def test_doctor_prints_update_notice_when_pypi_newer(self) -> None:
@@ -440,11 +440,25 @@ class CliSurfaceTest(unittest.TestCase):
     def test_roadmap_command_prints_guidance(self) -> None:
         stderr = io.StringIO()
         with redirect_stderr(stderr):
-            rc = cli.main(["add"])
+            rc = cli.main(["remove"])
         self.assertEqual(rc, 2)
         output = stderr.getvalue()
-        self.assertIn('"add" is planned for v0.2.', output)
+        self.assertIn('"remove" is planned', output)
         self.assertIn("ROADMAP.md", output)
+
+    def test_stage_alias_add_requires_target(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            rc = cli.main(["add"])
+        self.assertEqual(rc, 2)
+        self.assertIn("usage: morning-paper stage", stderr.getvalue())
+
+    def test_estimate_missing_file(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            rc = cli.main(["estimate", "/nonexistent/x.md"])
+        self.assertEqual(rc, 1)
+        self.assertIn("no such file", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces #8 (branch diverged after the #7 squash — same as last time; note to self: branch release branches from main).

- **`stage` / `queue` / `estimate`** — agent-facing verbs, JSON out: `morning-paper stage <url>` answers "adds ~5 pages, queued for the editor." `add`/`status` aliases; `page_budget` config key.
- **`editorial` style pack** — the unified paper per the design-consolidation spec: continuous outside folios, running section heads, separators not page breaks, CSS-drawn marks (zero tofu), black-ink-first color discipline. Print-proofed by owner.
- **Claude Code plugin skeleton** — `setup` + `edition` skills; README "For Agents" quickstart.

Tests 17/17. Version 0.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)