### PR TITLE
Cold-user fixes (0.4.1): honest stage truncation, install guidance, demo bridge, editorial defaults

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-paper",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "description": "Your personal newsroom: a daily printed paper composed by your agent from your sources, with preferences you own as files.",
   "author": { "name": "Devon Meadows", "url": "https://github.com/dmthepm" },
   "homepage": "https://github.com/dmthepm/morning-paper",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-06-11
+
+### Fixed
+- `stage <url>` (and `print <url>`) no longer truncate long articles silently. The article renderer keeps the first 80 extracted blocks; an ~11k-word essay was being staged at ~4.5k words with `staged: true` and a page estimate computed on the clipped text. The stage JSON now carries `truncated`, `words_extracted`, and a plain-language `warning` (exit stays 0), `print` surfaces the same warning, and a mid-sentence-cut check also flags extractions clipped upstream
+- README install guidance now leads with `uv tool install "morning-paper[pretty]"` (pipx as the alternative), documents the PEP 668 `externally-managed-environment` failure on brew/system Pythons, and keeps `pip` for venv users — the literal `pip install` line stranded non-venv users
+- Demo's "Make it yours" line now bridges the uvx try-it path to a persistent install (`uv tool install "morning-paper[pretty]" && morning-paper init`) — `morning-paper` was not on PATH for uvx users who typed the old suggestion verbatim
+- `.claude-plugin/plugin.json` version no longer lags the package (0.3.0 -> 0.4.1)
+- Starter config comment now lists all six styles instead of three
+
+### Changed
+- Default `outputs.style`/`outputs.palette` are now `editorial`/`color` — the first personal edition now matches the look the demo sold (renderer stays `typewriter`)
+
+### Added
+- `build`, `demo`, `print`, and `render` JSON output now report `"pages"` — the page count of the produced PDF (null when no PDF is written)
+
 ## [0.4.0] - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ uvx --from "morning-paper[pretty]" morning-paper demo
 
 > macOS first: `brew install pango gdk-pixbuf` (WeasyPrint needs Pango).
 
-Or with pip:
+Or keep it on your PATH instead of a one-off run:
 
 ```bash
-pip install "morning-paper[pretty]"
+uv tool install "morning-paper[pretty]"
 morning-paper demo
 ```
 
@@ -49,7 +49,9 @@ skill composes and prints each day's paper.
 
 Your human wants a daily printed paper. You can give them one:
 
-1. Install: `pip install "morning-paper[pretty]"` then `morning-paper doctor`.
+1. Install: `uv tool install "morning-paper[pretty]"` (or
+   `pipx install "morning-paper[pretty]"`; use `pip` only inside a venv —
+   PEP 668 blocks it on brew/system Pythons), then `morning-paper doctor`.
    `morning-paper demo` proves the print path end to end.
 2. If this repo is installed as a Claude Code plugin, run the `setup` skill —
    it interviews the reader, creates their private newsroom repo (preferences
@@ -94,11 +96,19 @@ prints a newspaper.
 ## Your daily paper
 
 ```bash
-pip install "morning-paper[pretty]"
+uv tool install "morning-paper[pretty]"
 morning-paper init      # starter config
 morning-paper doctor    # must say: typewriter ready
 morning-paper build     # today's edition
 ```
+
+`pipx install "morning-paper[pretty]"` works the same way. Prefer either
+over bare `pip`: on Macs and Linux boxes whose default Python is Homebrew's
+or the distro's, `pip install` outside a virtual environment fails with
+`externally-managed-environment` (PEP 668), and inside an existing
+environment it can silently keep an older version unless you pass
+`--upgrade`. If you manage your own venv,
+`pip install "morning-paper[pretty]"` is still fine.
 
 Artifacts land under:
 
@@ -106,8 +116,8 @@ Artifacts land under:
 ~/.local/share/morning-paper/<date>/
 ```
 
-The plain `pip install morning-paper` fallback works, but it is not the
-renderer you should judge the product by.
+The plain `morning-paper` install (no `[pretty]`) falls back to a simpler
+renderer — it works, but it is not the output you should judge the product by.
 
 ## Sources
 

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -22,9 +22,10 @@ sources:
 outputs:
   directory: ~/.local/share/morning-paper
   renderer: typewriter
-  # style: typewriter | flow | ops-card    palette: mono | color
-  style: typewriter
-  palette: mono
+  # style: editorial | typewriter | flow | magazine | ops-card | zine    palette: mono | color
+  # editorial/color is what the demo prints — the default recommendation
+  style: editorial
+  palette: color
   pdf: true
   html: true
   markdown: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.4.0"
+version = "0.4.1"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/src/morning_paper/article_print.py
+++ b/src/morning_paper/article_print.py
@@ -542,6 +542,55 @@ def fetch_article(url: str, *, extractor_name: str = "jina") -> Article:
     )
 
 
+_SENTENCE_END_PATTERN = re.compile(r"[.!?…\"”'’)\]:]$")
+
+
+def article_truncation_report(article: Article) -> dict[str, object]:
+    """Honesty check: report whether rendering will clip this article.
+
+    `render_article_markdown` caps body blocks at MAX_RENDER_BLOCKS, so a long
+    essay loses its tail at render time. Separately, the upstream extractor can
+    clip a page mid-sentence. Both cases must be surfaced, never silent.
+    """
+    text_blocks = [(kind, value) for kind, value in (article.blocks or []) if kind != "image"]
+    if article.blocks:
+        words_extracted = sum(len(value.split()) for _kind, value in text_blocks)
+        words_rendered = sum(
+            len(value.split()) for kind, value in article.blocks[:MAX_RENDER_BLOCKS] if kind != "image"
+        )
+        blocks_dropped = max(0, len(article.blocks) - MAX_RENDER_BLOCKS)
+    else:
+        words_extracted = words_rendered = len(article.body.split())
+        blocks_dropped = 0
+    last_text = (text_blocks[-1][1] if text_blocks else article.body).strip()
+    ends_mid_sentence = bool(last_text) and not _SENTENCE_END_PATTERN.search(last_text)
+    truncated = blocks_dropped > 0 or ends_mid_sentence
+    reasons: list[str] = []
+    if blocks_dropped:
+        reasons.append(
+            f"the render cap keeps the first {MAX_RENDER_BLOCKS} of {len(article.blocks)} extracted blocks"
+        )
+    if ends_mid_sentence:
+        reasons.append("the extracted text ends mid-sentence, so the source was likely clipped during extraction")
+    return {
+        "truncated": truncated,
+        "words_extracted": words_extracted,
+        "words_rendered": words_rendered,
+        "reason": "; ".join(reasons),
+    }
+
+
+def article_truncation_warning(article: Article) -> str:
+    """Plain-language warning when an article will print incomplete, else ''."""
+    report = article_truncation_report(article)
+    if not report["truncated"]:
+        return ""
+    return (
+        f"truncated: extracted {report['words_extracted']} words but only ~{report['words_rendered']} "
+        f"will print ({report['reason']}); the staged copy and its page estimate cover the truncated text only"
+    )
+
+
 def render_article_markdown(config: MorningPaperConfig, articles: list[Article], *, date_str: str, images_dir: Path) -> str:
     date_label = datetime.fromisoformat(date_str).strftime("%A, %B %d, %Y")
     css = """

--- a/src/morning_paper/builder.py
+++ b/src/morning_paper/builder.py
@@ -11,7 +11,7 @@ from .sources import collect_sources
 def build_paper(config: MorningPaperConfig, *, date_str: str | None = None) -> dict[str, object]:
     target_date = date_str or datetime.now(ZoneInfo(config.timezone)).date().isoformat()
     collected, errors = collect_sources(config)
-    outputs, warnings = write_outputs(config, collected, date_str=target_date)
+    outputs, warnings, pages = write_outputs(config, collected, date_str=target_date)
     return {
         "date": target_date,
         "name": config.name,
@@ -19,6 +19,7 @@ def build_paper(config: MorningPaperConfig, *, date_str: str | None = None) -> d
         "source_errors": errors,
         "warnings": warnings,
         "renderer": config.outputs.renderer,
+        "pages": pages,
         "outputs": {key: str(value) for key, value in outputs.items() if key != "dir"},
         "output_dir": str(outputs["dir"]),
     }

--- a/src/morning_paper/cli.py
+++ b/src/morning_paper/cli.py
@@ -10,7 +10,13 @@ from zoneinfo import ZoneInfo
 
 import requests
 
-from .article_print import ArticleExtractionError, fetch_article, render_article_markdown
+from .article_print import (
+    ArticleExtractionError,
+    article_truncation_report,
+    article_truncation_warning,
+    fetch_article,
+    render_article_markdown,
+)
 from .builder import build_paper
 from .config import DEFAULT_CONFIG_PATH, ConfigError, MorningPaperConfig, load_config, render_default_config
 from .renderers import TypewriterRendererUnavailable, _load_weasyprint, write_custom_markdown, _safe_filename
@@ -202,7 +208,7 @@ def demo_command(args: list[str]) -> int:
     config.outputs.pdf = True
     target_date = datetime.now(ZoneInfo(config.timezone)).date().isoformat()
     try:
-        outputs, warnings = write_custom_markdown(
+        outputs, warnings, pages = write_custom_markdown(
             config,
             markdown_text,
             date_str=target_date,
@@ -221,6 +227,7 @@ def demo_command(args: list[str]) -> int:
                 "mode": "demo",
                 "style": "editorial",
                 "palette": "color",
+                "pages": pages,
                 "warnings": warnings,
                 "outputs": {key: str(value) for key, value in outputs.items() if key != "dir"},
                 "output_dir": str(outputs["dir"]),
@@ -229,7 +236,7 @@ def demo_command(args: list[str]) -> int:
         )
     )
     print(f"Print it: lp {outputs['pdf']}")
-    print("Make it yours: morning-paper init (or run the setup skill in Claude Code)")
+    print('Make it yours: uv tool install "morning-paper[pretty]" && morning-paper init (or run the setup skill in Claude Code)')
     print("Post your paper: https://github.com/dmthepm/morning-paper/discussions")
     return 0
 
@@ -352,8 +359,14 @@ def print_command(args: list[str]) -> int:
     target_date = date or datetime.now(ZoneInfo(config.timezone)).date().isoformat()
     bundle_title = title or articles[0].title
     slug = _safe_filename(bundle_title)[:48] or "article-print"
+    # Honesty rule: never silently clip — flag any article that will print incomplete.
+    truncation_warnings = [
+        f"{article.url} {message}"
+        for article in articles
+        if (message := article_truncation_warning(article))
+    ]
     try:
-        outputs, warnings = write_custom_markdown(
+        outputs, warnings, pages = write_custom_markdown(
             config,
             render_article_markdown(
                 config,
@@ -368,6 +381,7 @@ def print_command(args: list[str]) -> int:
     except TypewriterRendererUnavailable as exc:
         print(str(exc), file=sys.stderr)
         return 1
+    warnings = truncation_warnings + warnings
     for warning in warnings:
         print(f"warning: {warning}", file=sys.stderr)
     print(
@@ -376,6 +390,7 @@ def print_command(args: list[str]) -> int:
                 "date": target_date,
                 "mode": "print",
                 "article_count": len(articles),
+                "pages": pages,
                 "warnings": warnings,
                 "outputs": {key: str(value) for key, value in outputs.items() if key != "dir"},
                 "output_dir": str(outputs["dir"]),
@@ -462,7 +477,7 @@ def render_command(args: list[str]) -> int:
     target_date = date or datetime.now(ZoneInfo(config.timezone)).date().isoformat()
     target_slug = _safe_filename(slug or source.stem)[:48] or "render"
     try:
-        outputs, warnings = write_custom_markdown(
+        outputs, warnings, pages = write_custom_markdown(
             config,
             markdown_text,
             date_str=target_date,
@@ -489,6 +504,7 @@ def render_command(args: list[str]) -> int:
                 "mode": "render",
                 "style": config.outputs.style,
                 "palette": config.outputs.palette,
+                "pages": pages,
                 "warnings": warnings,
                 "outputs": {key: str(value) for key, value in outputs.items() if key != "dir"},
                 "output_dir": str(outputs["dir"]),
@@ -558,9 +574,15 @@ def stage_command(args: list[str]) -> int:
             date_str=date_str,
             images_dir=config.outputs.directory / "staging" / date_str / "_images",
         )
+        # Honesty rule: if extraction or the render cap clipped the article,
+        # say so plainly in the JSON instead of staging silently.
+        report = article_truncation_report(article)
         item = stage_markdown(
             config, markdown, date_str=date_str, kind="url", source=target,
             title=title_override or article.title,
+            truncated=bool(report["truncated"]),
+            words_extracted=int(report["words_extracted"]),
+            warning=article_truncation_warning(article),
         )
     else:
         source = Path(target).expanduser()

--- a/src/morning_paper/config.py
+++ b/src/morning_paper/config.py
@@ -40,8 +40,9 @@ class SourcesConfig:
 class OutputsConfig:
     directory: Path = DEFAULT_OUTPUT_DIR
     renderer: str = "typewriter"
-    style: str = "typewriter"
-    palette: str = "mono"
+    # editorial/color is the product's visual identity — the same look the demo sells
+    style: str = "editorial"
+    palette: str = "color"
     pdf: bool = True
     html: bool = True
     markdown: bool = True
@@ -154,8 +155,8 @@ def load_config(path: Path) -> MorningPaperConfig:
                 _expand_path(outputs.get("directory"), default=DEFAULT_OUTPUT_DIR)
             ),
             renderer=_validate_renderer(str(outputs.get("renderer", "typewriter"))),
-            style=_validate_style(str(outputs.get("style", "typewriter"))),
-            palette=_validate_palette(str(outputs.get("palette", "mono"))),
+            style=_validate_style(str(outputs.get("style", "editorial"))),
+            palette=_validate_palette(str(outputs.get("palette", "color"))),
             pdf=bool(outputs.get("pdf", True)),
             html=bool(outputs.get("html", True)),
             markdown=bool(outputs.get("markdown", True)),
@@ -214,9 +215,10 @@ sources:
 outputs:
   directory: ~/.local/share/morning-paper
   renderer: typewriter
-  # style: typewriter | flow | ops-card    palette: mono | color
-  style: typewriter
-  palette: mono
+  # style: editorial | typewriter | flow | magazine | ops-card | zine    palette: mono | color
+  # editorial/color is what the demo prints — the default recommendation
+  style: editorial
+  palette: color
   pdf: true
   html: true
   markdown: true

--- a/src/morning_paper/renderers.py
+++ b/src/morning_paper/renderers.py
@@ -343,7 +343,7 @@ def render_typewriter_html(config: MorningPaperConfig, collected: dict[str, list
     return _render_html_from_markdown(markdown, style=config.outputs.style, palette=config.outputs.palette)
 
 
-def render_pdf(config: MorningPaperConfig, collected: dict[str, list[SourceItem]], *, date_str: str, output_path: Path) -> None:
+def render_pdf(config: MorningPaperConfig, collected: dict[str, list[SourceItem]], *, date_str: str, output_path: Path) -> int:
     pdf = FPDF(format="Letter")
     pdf.set_auto_page_break(auto=True, margin=12)
     pdf.add_page()
@@ -383,7 +383,9 @@ def render_pdf(config: MorningPaperConfig, collected: dict[str, list[SourceItem]
             pdf.multi_cell(width, 5, _pdf_text(item.url))
             pdf.ln(1)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    pages = pdf.page
     pdf.output(str(output_path))
+    return pages
 
 
 def _render_html_from_markdown(markdown: str, *, style: str = "typewriter", palette: str = "mono") -> str:
@@ -407,13 +409,15 @@ def _render_html_from_markdown(markdown: str, *, style: str = "typewriter", pale
     )
 
 
-def _render_typewriter_pdf(markdown: str, *, output_path: Path, style: str = "typewriter", palette: str = "mono") -> None:
+def _render_typewriter_pdf(markdown: str, *, output_path: Path, style: str = "typewriter", palette: str = "mono") -> int:
     html_cls, error = _load_weasyprint()
     if html_cls is None:
         raise RuntimeError(error or "WeasyPrint unavailable")
     html_doc = _render_html_from_markdown(markdown, style=style, palette=palette)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    html_cls(string=html_doc, base_url=str(output_path.parent)).write_pdf(str(output_path))
+    document = html_cls(string=html_doc, base_url=str(output_path.parent)).render()
+    document.write_pdf(str(output_path))
+    return len(document.pages)
 
 
 def count_pages(markdown: str, *, style: str = "typewriter", palette: str = "mono") -> int:
@@ -429,7 +433,7 @@ def count_pages(markdown: str, *, style: str = "typewriter", palette: str = "mon
     return len(html_cls(string=html_doc).render().pages)
 
 
-def _render_markdown_text_pdf(config: MorningPaperConfig, markdown: str, *, date_str: str, output_path: Path) -> None:
+def _render_markdown_text_pdf(config: MorningPaperConfig, markdown: str, *, date_str: str, output_path: Path) -> int:
     _meta, body = _split_frontmatter(markdown)
     rendered_body = _MARKDOWN.render(body)
     plain = html.unescape(rendered_body)
@@ -455,13 +459,22 @@ def _render_markdown_text_pdf(config: MorningPaperConfig, markdown: str, *, date
         line = _pdf_text(line.replace("# ", "").replace("## ", "").replace("### ", ""))
         pdf.multi_cell(width, 5, line)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    pages = pdf.page
     pdf.output(str(output_path))
+    return pages
 
 
-def write_outputs(config: MorningPaperConfig, collected: dict[str, list[SourceItem]], *, date_str: str) -> tuple[dict[str, Path], list[str]]:
+def write_outputs(
+    config: MorningPaperConfig, collected: dict[str, list[SourceItem]], *, date_str: str
+) -> tuple[dict[str, Path], list[str], int | None]:
+    """Write the configured artifacts; returns (paths, warnings, pdf page count).
+
+    The page count is None when no PDF was produced.
+    """
     paths = output_paths(config, date_str)
     paths["dir"].mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
+    pages: int | None = None
     markdown = (
         render_typewriter_markdown(config, collected, date_str=date_str)
         if config.outputs.renderer == "typewriter"
@@ -488,7 +501,7 @@ def write_outputs(config: MorningPaperConfig, collected: dict[str, list[SourceIt
     if config.outputs.pdf:
         if config.outputs.renderer == "typewriter":
             try:
-                _render_typewriter_pdf(
+                pages = _render_typewriter_pdf(
                     markdown,
                     output_path=paths["pdf"],
                     style=config.outputs.style,
@@ -503,8 +516,8 @@ def write_outputs(config: MorningPaperConfig, collected: dict[str, list[SourceIt
                     f"Detail: {exc}"
                 )
         else:
-            render_pdf(config, collected, date_str=date_str, output_path=paths["pdf"])
-    return paths, warnings
+            pages = render_pdf(config, collected, date_str=date_str, output_path=paths["pdf"])
+    return paths, warnings, pages
 
 
 def write_custom_markdown(
@@ -514,10 +527,15 @@ def write_custom_markdown(
     date_str: str,
     slug: str,
     metadata: dict[str, object] | None = None,
-) -> tuple[dict[str, Path], list[str]]:
+) -> tuple[dict[str, Path], list[str], int | None]:
+    """Write artifacts for caller-supplied markdown; returns (paths, warnings, pdf page count).
+
+    The page count is None when no PDF was produced.
+    """
     paths = custom_output_paths(config, date_str, slug=slug)
     paths["dir"].mkdir(parents=True, exist_ok=True)
     warnings: list[str] = []
+    pages: int | None = None
     if config.outputs.json:
         payload = {
             "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -537,7 +555,7 @@ def write_custom_markdown(
     if config.outputs.pdf:
         if config.outputs.renderer == "typewriter":
             try:
-                _render_typewriter_pdf(
+                pages = _render_typewriter_pdf(
                     markdown,
                     output_path=paths["pdf"],
                     style=config.outputs.style,
@@ -552,5 +570,5 @@ def write_custom_markdown(
                     f"Detail: {exc}"
                 )
         else:
-            _render_markdown_text_pdf(config, markdown, date_str=date_str, output_path=paths["pdf"])
-    return paths, warnings
+            pages = _render_markdown_text_pdf(config, markdown, date_str=date_str, output_path=paths["pdf"])
+    return paths, warnings, pages

--- a/src/morning_paper/resources/demo.md
+++ b/src/morning_paper/resources/demo.md
@@ -60,7 +60,7 @@ The vote is scheduled for tonight, after the matter of the pier lamps. The keepe
 
 <div class="move">
 <span class="move-label">The Move</span>
-This page is the demo. Make it yours: run <code>morning-paper init</code>, point the config at your own feeds, and queue tomorrow's reading with <code>morning-paper stage</code> — the edition prints itself each morning.
+This page is the demo. Make it yours: install with <code>uv tool install "morning-paper[pretty]"</code>, run <code>morning-paper init</code>, point the config at your own feeds, and queue tomorrow's reading with <code>morning-paper stage</code> — the edition prints itself each morning.
 </div>
 
 <div class="edition-divider"><div class="oxford"></div><div class="edition-divider-label">Today's Queue</div></div>

--- a/src/morning_paper/staging.py
+++ b/src/morning_paper/staging.py
@@ -31,6 +31,9 @@ class StagedItem:
     words: int
     est_pages: int
     staged_at: str
+    truncated: bool = False           # honesty flag: the staged copy is incomplete
+    words_extracted: int | None = None  # words the extractor recovered before any render cap
+    warning: str = ""                 # plain-language explanation when truncated
 
 
 def staging_dir(config: MorningPaperConfig, date_str: str) -> Path:
@@ -63,6 +66,9 @@ def stage_markdown(
     kind: str,
     source: str,
     title: str,
+    truncated: bool = False,
+    words_extracted: int | None = None,
+    warning: str = "",
 ) -> StagedItem:
     sdir = staging_dir(config, date_str)
     slug = _safe_filename(title)[:48] or "staged"
@@ -86,6 +92,9 @@ def stage_markdown(
         words=len(markdown.split()),
         est_pages=pages,
         staged_at=datetime.now(ZoneInfo(config.timezone)).isoformat(timespec="seconds"),
+        truncated=truncated,
+        words_extracted=words_extracted,
+        warning=warning,
     )
     queue.append(asdict(item))
     _save_queue(sdir, queue)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -157,6 +157,10 @@ class BuildFlowTest(unittest.TestCase):
             self.assertTrue(config_path.exists())
 
             config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            # the starter config matches the visual identity the demo sells
+            self.assertEqual(config["outputs"]["style"], "editorial")
+            self.assertEqual(config["outputs"]["palette"], "color")
+            self.assertEqual(config["outputs"]["renderer"], "typewriter")
             config["outputs"]["directory"] = str(output_dir)
             config["outputs"]["renderer"] = "portable"
             config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
@@ -175,6 +179,8 @@ class BuildFlowTest(unittest.TestCase):
                 self.assertTrue(path.exists(), key)
                 self.assertGreater(path.stat().st_size, 0, key)
             self.assertEqual(payload["renderer"], "portable")
+            self.assertIsInstance(payload["pages"], int)
+            self.assertGreaterEqual(payload["pages"], 1)
             self.assertIsInstance(payload["warnings"], list)
 
     def test_print_writes_outputs_for_article_bundle(self) -> None:

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -52,13 +52,18 @@ class DemoCommandTest(unittest.TestCase):
             self.assertEqual(payload["mode"], "demo")
             self.assertEqual(payload["style"], "editorial")
             self.assertEqual(payload["palette"], "color")
+            self.assertIsInstance(payload["pages"], int)
+            self.assertGreaterEqual(payload["pages"], 1)
             for key in ("json", "markdown", "html", "pdf"):
                 path = Path(payload["outputs"][key])
                 self.assertTrue(path.exists(), key)
                 self.assertGreater(path.stat().st_size, 0, key)
 
             self.assertEqual(lines[-3], f"Print it: lp {payload['outputs']['pdf']}")
-            self.assertEqual(lines[-2], "Make it yours: morning-paper init (or run the setup skill in Claude Code)")
+            self.assertEqual(
+                lines[-2],
+                'Make it yours: uv tool install "morning-paper[pretty]" && morning-paper init (or run the setup skill in Claude Code)',
+            )
             self.assertEqual(lines[-1], "Post your paper: https://github.com/dmthepm/morning-paper/discussions")
 
             # offline-deterministic: the typeset HTML carries vendored fonts, no network fetches

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from morning_paper import cli
+from morning_paper.article_print import (
+    MAX_RENDER_BLOCKS,
+    Article,
+    article_truncation_report,
+    article_truncation_warning,
+)
+
+
+SENTENCE = "This is a complete sentence with enough words to look like a real paragraph of prose."
+WORDS_PER_BLOCK = len(SENTENCE.split())
+
+
+def _article(block_count: int) -> Article:
+    return Article(
+        url="https://example.com/long-essay",
+        title="A Very Long Essay",
+        author="Author",
+        source_name="Example",
+        body="",
+        blocks=[("paragraph", SENTENCE) for _ in range(block_count)],
+    )
+
+
+class TruncationReportTest(unittest.TestCase):
+    def test_render_cap_overflow_is_flagged(self) -> None:
+        overflow = 40
+        article = _article(MAX_RENDER_BLOCKS + overflow)
+        report = article_truncation_report(article)
+        self.assertTrue(report["truncated"])
+        self.assertEqual(report["words_extracted"], WORDS_PER_BLOCK * (MAX_RENDER_BLOCKS + overflow))
+        self.assertEqual(report["words_rendered"], WORDS_PER_BLOCK * MAX_RENDER_BLOCKS)
+        self.assertIn(str(MAX_RENDER_BLOCKS), str(report["reason"]))
+        warning = article_truncation_warning(article)
+        self.assertIn("truncated", warning)
+        self.assertIn(str(report["words_extracted"]), warning)
+
+    def test_complete_article_is_not_flagged(self) -> None:
+        article = _article(5)
+        report = article_truncation_report(article)
+        self.assertFalse(report["truncated"])
+        self.assertEqual(report["words_extracted"], report["words_rendered"])
+        self.assertEqual(article_truncation_warning(article), "")
+
+    def test_mid_sentence_extraction_cut_is_flagged(self) -> None:
+        article = _article(3)
+        article.blocks[-1] = ("paragraph", "This final paragraph stops in the middle of a")
+        report = article_truncation_report(article)
+        self.assertTrue(report["truncated"])
+        self.assertIn("mid-sentence", str(report["reason"]))
+
+
+class StageTruncationTest(unittest.TestCase):
+    def _stage(self, article: Article) -> dict:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "config.yaml"
+            rc = cli.main(["init", "--config", str(config_path)])
+            self.assertEqual(rc, 0)
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            config["outputs"]["directory"] = str(tmp_path / "out")
+            config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+            stdout = io.StringIO()
+            with patch("morning_paper.cli.fetch_article", return_value=article):
+                with redirect_stdout(stdout):
+                    rc = cli.main(
+                        [
+                            "stage",
+                            article.url,
+                            "--config",
+                            str(config_path),
+                            "--date",
+                            "2026-06-12",
+                        ]
+                    )
+            self.assertEqual(rc, 0)
+            payload = json.loads(stdout.getvalue())
+
+            queue_file = tmp_path / "out" / "staging" / "2026-06-12" / "queue.json"
+            self.assertTrue(queue_file.exists())
+            payload["_queue"] = json.loads(queue_file.read_text(encoding="utf-8"))
+            return payload
+
+    def test_stage_url_reports_truncation_honestly(self) -> None:
+        overflow = 40
+        payload = self._stage(_article(MAX_RENDER_BLOCKS + overflow))
+        self.assertTrue(payload["staged"])
+        self.assertTrue(payload["truncated"])
+        self.assertEqual(payload["words_extracted"], WORDS_PER_BLOCK * (MAX_RENDER_BLOCKS + overflow))
+        self.assertIn("truncated", payload["warning"])
+        self.assertIn(str(payload["words_extracted"]), payload["warning"])
+        # the queue carries the same honesty flags for later passes
+        queued = payload["_queue"][0]
+        self.assertTrue(queued["truncated"])
+        self.assertEqual(queued["words_extracted"], payload["words_extracted"])
+        self.assertEqual(queued["warning"], payload["warning"])
+
+    def test_stage_url_of_complete_article_carries_no_warning(self) -> None:
+        payload = self._stage(_article(5))
+        self.assertTrue(payload["staged"])
+        self.assertFalse(payload["truncated"])
+        self.assertEqual(payload["warning"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the four P1s and the cheap P2s from cold-user simulation 1 (fresh-HOME README walkthrough of 0.4.0).

## P1-1 — `stage <url>` silently truncated long articles
**Root cause:** not the anonymous Jina tier (it returned the full ~11.8k-word essay, 229 blocks). The clip happens at render time: `render_article_markdown` keeps only the first `MAX_RENDER_BLOCKS = 80` blocks, so "How to Do Great Work" staged at ~4.5k words with `staged: true`, no warning, and a page estimate computed on the clipped text.

**Fix:** new `article_truncation_report` / `article_truncation_warning` in `article_print.py`. `stage` JSON (and `queue.json`) now carry `truncated`, `words_extracted`, and a plain-language `warning`; exit stays 0. `print` surfaces the same warning in its `warnings` list. A mid-sentence-cut check additionally flags extractions clipped upstream. Verified against the live essay:

```json
"words": 4536,
"truncated": true,
"words_extracted": 11826,
"warning": "truncated: extracted 11826 words but only ~4159 will print (the render cap keeps the first 80 of 229 extracted blocks); ..."
```

## P1-2 — install guidance
README now leads with `uv tool install "morning-paper[pretty]"`, offers pipx as the alternative, documents the PEP 668 `externally-managed-environment` failure on brew/system Pythons and pip's silent keep-stale behavior, and keeps `pip` for venv users.

## P1-3 — demo bridge
Demo's share-loop line is now `Make it yours: uv tool install "morning-paper[pretty]" && morning-paper init (or run the setup skill in Claude Code)` — uvx users no longer get told to run a command that is not on their PATH. The printed demo colophon got the same bridge. Test updated.

## P1-4 — default style matches the demo
`init` and the config dataclass now default to `style: editorial`, `palette: color` (renderer stays `typewriter`) — the first personal edition prints in the visual identity the demo sold (owner-ratified). Example config updated; init test asserts the new defaults.

Note: the `build` front-page template still uses the typewriter class vocabulary, which the editorial pack does not style — the keyless build renders legibly in editorial serif but loses the card/info-row treatment. Teaching the editorial pack the front-page vocabulary is flagged as follow-up work.

## P2s
- Starter/example config comment lists all six styles (was three)
- `.claude-plugin/plugin.json` version unstuck (0.3.0 -> 0.4.1)
- `build` / `demo` / `print` / `render` JSON now report `"pages"` (counted from the real render; null when no PDF)
- Version 0.4.1 in pyproject + `__init__`, CHANGELOG entry added

## Tests
32 passing (27 baseline + 5 new: truncation report unit tests and stage CLI truncation/no-warning tests). Live-verified: stage of the PG essay, demo (pages: 2, new bridge line), keyless build (pages: 4), file stage and render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)