### PR TITLE
Local-first extraction and the AI setup prompt (0.4.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-paper",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Your personal newsroom: a daily printed paper composed by your agent from your sources, with preferences you own as files.",
   "author": { "name": "Devon Meadows", "url": "https://github.com/dmthepm" },
   "homepage": "https://github.com/dmthepm/morning-paper",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-06-11
+
+### Added
+- `local` article extractor — fetches the page directly from your machine and parses it with trafilatura (now a core dependency). It is the **default** for `print`/`stage`: the URLs you read never leave your computer. Headings, blockquotes, and inline images carry through to print; the validation gate and truncation reporting work identically to the jina path
+- "Set up with AI (recommended)" section at the top of the README — a copy-paste prompt that walks any strong model through the full onboarding arc (read, explore, interview, install, doctor, demo, private newsroom repo, first printed edition, daily loop), mirrored in the For Agents section
+- Stage JSON now carries `extractor_note`; `print` output adds a warning line when the extractor fell back
+
+### Changed
+- `jina` (`r.jina.ai`) is demoted from default to explicit option + automatic fallback. Privacy note, stated plainly in README and docs: jina sends each URL you read to a third-party service. When local extraction recovers too little content the engine chains `local -> jina` and flags the result with an honest note — never a silent fallback
+- Default config (`init`) now writes `article_extractor: local` with the privacy trade documented in a comment
+
 ## [0.4.1] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,6 +11,27 @@
 
 ---
 
+## Set up with AI (recommended)
+
+Open your strongest model — Claude Fable with the 1M context works great — and paste this:
+
+```text
+I want a Morning Paper: an open-source personal newspaper my agent composes
+and prints, with preferences I own as files
+(https://github.com/dmthepm/morning-paper). First read the entire README,
+then explore the repo enough to understand the architecture (agent composes,
+code renders; a private newsroom repo holds my preference files; the honesty
+doctrine binds). Then interview me briefly about my sources, page budget, and
+printer. Then: install the engine, run `morning-paper doctor` and fix
+anything it flags, run `morning-paper demo` so I see the product, create my
+private newsroom repo, build my first real edition, and teach me the daily
+loop — including the desk sheet and how my handwritten notes get read back.
+Get me to a printed (or PDF) first edition, then stop and show me what you
+set up.
+```
+
+Prefer to drive it yourself? Everything below is the manual path.
+
 ## Try it
 
 Typeset the bundled sample edition — no config, no network, no keys:
@@ -47,7 +68,10 @@ skill composes and prints each day's paper.
 
 ## For Agents (read this first if you are one)
 
-Your human wants a daily printed paper. You can give them one:
+Your human wants a daily printed paper. You can give them one. If they pasted
+the ["Set up with AI" prompt](#set-up-with-ai-recommended) above, follow it —
+it is the full onboarding arc (read, explore, interview, install, demo,
+newsroom repo, first edition, daily loop). Otherwise:
 
 1. Install: `uv tool install "morning-paper[pretty]"` (or
    `pipx install "morning-paper[pretty]"`; use `pip` only inside a venv —
@@ -70,9 +94,12 @@ Your human wants a daily printed paper. You can give them one:
    `estimate` fails without it, and `stage` falls back to a rough
    words-per-page heuristic instead of a real layout pass. Run
    `morning-paper doctor` first if the numbers matter.
-5. URL fetching goes through the anonymous Jina Reader tier: no key needed,
-   but rate limits and a 40-second timeout apply. Failures raise clean
-   errors instead of staging garbage.
+5. Article extraction is local by default (`trafilatura`): the URL is fetched
+   from this machine and never sent to a third party. If local extraction
+   recovers too little, the `jina` fallback re-fetches through `r.jina.ai`
+   (anonymous tier: shared rate limits, 40-second timeout) and the result
+   carries an honest note saying the URL left the machine. Failures raise
+   clean errors instead of staging garbage.
 6. Composition contract, class vocabulary, and chart directives: [docs/composing.md](docs/composing.md).
 7. Honesty rule: a section with no data says "not configured" — never fabricate.
 
@@ -161,13 +188,21 @@ silently generating a lower-quality PDF. `morning-paper doctor` says plainly
 which path you are on, and on macOS prints the exact Pango fix when that is
 the problem.
 
-Article extraction defaults to the anonymous Jina Reader tier (`r.jina.ai`):
-no API key, shared rate limits, 40-second timeout. Some domains (YouTube,
-GitHub, Instagram, LinkedIn, HN comment pages) do not extract meaningfully
-and are rejected with a clear error. A validation gate rejects shell pages
-and too-short extractions instead of printing garbage. Extraction is a
-replaceable backend; the renderer, validation, and image pipeline are
-designed to survive extractor upgrades.
+Article extraction defaults to `local`: the page is fetched directly from
+your machine and parsed with [trafilatura](https://trafilatura.readthedocs.io/)
+— no API key, no rate limits, and **the URLs you read never leave your
+computer**. The `jina` extractor (the anonymous `r.jina.ai` reader tier)
+remains available, and runs automatically as a fallback when local
+extraction recovers too little content — with the privacy trade stated
+plainly: jina sends each URL to a third-party service, so the fallback is
+flagged with an honest note in the `print`/`stage` output rather than
+happening silently. Set `article_extractor: jina` in config if you prefer
+the remote reader. Some domains (YouTube, GitHub, Instagram, LinkedIn, HN
+comment pages) do not extract meaningfully and are rejected with a clear
+error. A validation gate rejects shell pages and too-short extractions
+instead of printing garbage. Extraction is a replaceable backend; the
+renderer, validation, and image pipeline are designed to survive extractor
+upgrades.
 
 ## The honesty doctrine
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -31,6 +31,13 @@
 - vendored Courier Prime (OFL) for offline-deterministic rendering
 - `doctor --json` and `doctor --strict` for machine-readable install checks
 
+## Shipped (`v0.4.2`)
+
+- `local` article extractor (trafilatura, core dependency) as the default —
+  URLs stay on your machine; `jina` demoted to explicit option + honest
+  auto-fallback with a privacy note in the result
+- "Set up with AI" onboarding prompt at the top of the README
+
 ## Next (`v0.4`)
 
 - queue management verbs: `morning-paper remove`, `morning-paper list`
@@ -49,4 +56,5 @@
 - coverage / breadth analysis for major stories
 - image-of-the-day or full-page visual mode
 - E Ink / device delivery surfaces
-- additional extractor backends beyond Jina
+- additional extractor backends beyond `local` and `jina` (readability exports,
+  paywalled-page sessions)

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -170,6 +170,16 @@ X.com is actively hostile to content extraction. There is no free, open source, 
   3. `manual` — user pastes thread content as markdown (always works)
 - If no X backend is configured and user tries an X URL: clear message with options, never a broken/garbage PDF.
 
+> **Amended 2026-06-11 (0.4.2):** the default flipped. General article
+> extraction is now **local-first**: trafilatura ships as a core dependency
+> and `article_extractor: local` is the default — URLs stay on the reader's
+> machine. Jina Reader is demoted to an explicit option and an automatic
+> fallback when local extraction recovers too little content; the fallback
+> is always flagged with an honest note in the result, never silent. The
+> privacy concern (every read URL sent to a third-party SaaS) outweighed
+> the zero-dependency appeal of the original default. The `[local]` extra
+> described below no longer exists — trafilatura is core.
+
 ### pyproject.toml extras
 
 ```toml
@@ -178,6 +188,9 @@ pretty = ["weasyprint>=62.0"]
 twitter = ["twscrape"]
 local = ["trafilatura"]
 ```
+
+(As of 0.4.2: `twitter` and `local` extras were never wired and are gone;
+trafilatura moved into core `dependencies`.)
 
 ### Content validation gate
 
@@ -193,8 +206,11 @@ The February 2026 Pay-Per-Use pricing ($0.005/post, no free tier) makes it unsui
 ## 12. Article Extraction Architecture
 
 Decision date: 2026-04-14
+Amended: 2026-06-11 (0.4.2) — default is now the **local** trafilatura
+extractor; Jina Reader is the documented fallback in the `local -> jina`
+chain below and remains selectable via `article_extractor: jina`.
 
-Default extractor: **Jina Reader** (`https://r.jina.ai/{url}`)
+Original default extractor: **Jina Reader** (`https://r.jina.ai/{url}`)
 
 Request headers include `X-With-Images: true` which returns 33-90% more content on X Articles with better heading and image preservation.
 
@@ -205,10 +221,14 @@ Why Jina over trafilatura as the default:
 - Images come in print-friendly sizes (`small` variant, perfect for newspaper columns)
 - trafilatura drops images and requires extra parsing for the same content
 
-Fallback chain in `fetch_article()`:
-1. Jina Reader → if content passes validation gate → return Article
-2. If Jina fails validation → raise ArticleExtractionError with clear message
-3. For X URLs specifically: suggest configuring twitter backend or manual paste
+Fallback chain in `fetch_article()` (as of 0.4.2):
+1. Local trafilatura extraction → if it recovers enough content → return Article
+2. If local recovers too little → Jina Reader retry, result carries an honest
+   `extraction_note` ("the URL was sent to the third-party r.jina.ai service")
+3. If the winning extraction fails the validation gate → raise
+   ArticleExtractionError with clear message
+4. For X URLs specifically: the local fetch sees the noscript shell, so jina
+   handles X posts in practice; shell responses still fail with a clear error
 
 Content validation gate (implemented in v0.1.1):
 - Minimum 200 characters of extracted text
@@ -225,7 +245,7 @@ Image handling:
 Honest limitations:
 - Jina is an external free service — rate limits and future changes are possible
 - Some X posts fail extraction (noscript shell returned) — validation gate catches these
-- No offline mode without the optional `morning-paper[local]` extra (trafilatura)
+- ~~No offline mode without the optional `morning-paper[local]` extra (trafilatura)~~ — resolved in 0.4.2: trafilatura is core and local extraction is the default
 
 ## 13. X/Twitter Metadata via FxTwitter
 
@@ -291,8 +311,8 @@ Morning Paper should treat article extraction as a replaceable backend, not a pe
 
 Current shape:
 - extractor interface: `src/morning_paper/extractors.py`
-- current registered extractor: `jina`
-- config field: `article_extractor: jina`
+- registered extractors: `local` (default since 0.4.2) and `jina`
+- config field: `article_extractor: local` (or `jina`)
 - `fetch_article()` resolves the configured extractor, then applies shared validation, metadata enrichment, and rendering
 
 Reason:

--- a/docs/composing.md
+++ b/docs/composing.md
@@ -144,3 +144,30 @@ mandate — compose whichever zones a document needs. Everything is built on a
 A full single-sheet layout (no folio, no running heads) must null the
 editorial `@page` furniture in its own `<style>` block, across all three
 page contexts (base, `:left`, `:right`).
+
+## Article extraction (`print` / `stage`) and privacy
+
+When you hand the engine a URL (`morning-paper print <url>`,
+`morning-paper stage <url>`), an extractor turns the page into printable
+blocks. Two are registered:
+
+- `local` (default) — fetches the page directly from this machine and parses
+  it with trafilatura. **The URLs your reader cares about never leave their
+  computer.** No key, no rate limits, works offline-adjacent (only the
+  article's own host is contacted).
+- `jina` — sends the URL to the third-party `r.jina.ai` reader service
+  (anonymous tier: shared rate limits, 40-second timeout). Stronger on
+  JavaScript-heavy pages and X posts.
+
+The chain is `local -> jina`: when local extraction recovers too little
+content, the engine retries through jina and the result carries an honest
+note (`extraction_note` on the article, an `extractor_note` field in the
+stage JSON, and a warning line in `print` output) saying the URL was sent to
+the third-party service. It never falls back silently — if your reader's
+threat model forbids the remote reader entirely, respect the note and skip
+the article instead of staging it. Pin a backend with `article_extractor:
+local` or `article_extractor: jina` in config.
+
+Both paths feed the same validation gate (shell pages and too-short
+extractions are rejected, never printed) and the same truncation reporting
+(`truncated`, `words_extracted`, plain-language `warning`).

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -5,7 +5,9 @@ timezone: America/Los_Angeles
 profile: |
   Add a short note about who this paper is for and what should matter most.
   Example: early-stage AI tools, operator software, media, and founder signal.
-article_extractor: jina
+# local parses pages on this machine (URLs never leave your computer);
+# jina sends each URL to the third-party r.jina.ai reader service
+article_extractor: local
 
 sources:
   hacker_news:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.4.1"
+version = "0.4.2"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -41,6 +41,7 @@ dependencies = [
   "Pillow>=11.3.0",
   "PyYAML>=6.0.2",
   "requests>=2.32.3",
+  "trafilatura>=1.12",
 ]
 
 [project.optional-dependencies]

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/src/morning_paper/article_print.py
+++ b/src/morning_paper/article_print.py
@@ -21,6 +21,11 @@ class ArticleExtractionError(RuntimeError):
 
 JINA_TIMEOUT_SECONDS = 40
 PAGE_FETCH_TIMEOUT_SECONDS = 30
+LOCAL_FETCH_TIMEOUT_SECONDS = 30
+LOCAL_FETCH_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
 UNAVATAR_TIMEOUT_SECONDS = 10
 FXTWITTER_TIMEOUT_SECONDS = 15
 MIN_ARTICLE_LENGTH = 200
@@ -79,6 +84,9 @@ class Article:
     views: int | None = None
     bio: str | None = None
     blocks: list[tuple[str, str]] = field(default_factory=list)
+    # honesty note: set when extraction did not happen the way the config promised
+    # (for example: local extraction came up short and the jina fallback ran)
+    extraction_note: str = ""
 
 
 def _clean_text(value: str) -> str:
@@ -343,6 +351,125 @@ class JinaArticleExtractor:
 register_article_extractor(JinaArticleExtractor())
 
 
+MARKDOWN_IMAGE_PATTERN = re.compile(r"^!\[[^\]]*\]\((https?://[^)\s]+)[^)]*\)$")
+_MARKDOWN_INLINE_IMAGE_PATTERN = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+_MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_MARKDOWN_EMPHASIS_PATTERN = re.compile(r"(\*{1,3}|_{1,3}|`)(.+?)\1")
+
+
+def _strip_markdown_inline(text: str) -> str:
+    text = _MARKDOWN_INLINE_IMAGE_PATTERN.sub("", text)
+    text = _MARKDOWN_LINK_PATTERN.sub(r"\1", text)
+    previous = None
+    while previous != text:
+        previous = text
+        text = _MARKDOWN_EMPHASIS_PATTERN.sub(r"\2", text)
+    return " ".join(text.split())
+
+
+def _markdown_blocks(markdown_text: str) -> list[tuple[str, str]]:
+    """Parse extractor markdown into the renderer's block vocabulary.
+
+    Kinds: paragraph, blockquote, callout (headings), image. Mirrors the jina
+    parser's output shape so validation, truncation reporting, and rendering
+    work identically for both extraction paths.
+    """
+    blocks: list[tuple[str, str]] = []
+    current_kind: str | None = None
+    current_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal current_kind, current_lines
+        if current_kind and current_lines:
+            text = _strip_markdown_inline(" ".join(current_lines))
+            if text:
+                blocks.append((current_kind, text))
+        current_kind = None
+        current_lines = []
+
+    for raw in markdown_text.splitlines():
+        line = raw.strip()
+        if not line:
+            flush()
+            continue
+        image_match = MARKDOWN_IMAGE_PATTERN.match(line)
+        if image_match:
+            flush()
+            blocks.append(("image", image_match.group(1)))
+            continue
+        if line.startswith("#"):
+            flush()
+            heading = _strip_markdown_inline(line.lstrip("#"))
+            if heading:
+                blocks.append(("callout", heading))
+            continue
+        if line.startswith(">"):
+            cleaned = line.lstrip(">").strip()
+            if not cleaned:
+                continue
+            if current_kind != "blockquote":
+                flush()
+                current_kind = "blockquote"
+            current_lines.append(cleaned)
+            continue
+        if re.fullmatch(r"[\W_]+", line):
+            continue
+        if current_kind != "paragraph":
+            flush()
+            current_kind = "paragraph"
+        current_lines.append(line)
+    flush()
+    return blocks
+
+
+class LocalArticleExtractor:
+    """On-machine extraction: a direct fetch plus trafilatura.
+
+    Nothing about the URL or the page leaves this machine — unlike the `jina`
+    extractor, which sends each URL to the third-party r.jina.ai reader.
+    """
+
+    name = "local"
+
+    def extract(self, url: str) -> ExtractedArticleContent:
+        import trafilatura
+
+        response = requests.get(
+            url,
+            timeout=LOCAL_FETCH_TIMEOUT_SECONDS,
+            headers={"User-Agent": LOCAL_FETCH_USER_AGENT},
+        )
+        response.raise_for_status()
+        html_text = response.text
+        markdown_text = (
+            trafilatura.extract(
+                html_text,
+                url=url,
+                output_format="markdown",
+                include_images=True,
+                include_links=False,
+            )
+            or ""
+        )
+        metadata = None
+        try:
+            metadata = trafilatura.extract_metadata(html_text, default_url=url)
+        except Exception:
+            metadata = None
+        blocks = _markdown_blocks(markdown_text)
+        paragraphs = [text for kind, text in blocks if kind in {"paragraph", "blockquote", "callout"}]
+        return ExtractedArticleContent(
+            title=str(getattr(metadata, "title", "") or ""),
+            author=str(getattr(metadata, "author", "") or ""),
+            image_url=str(getattr(metadata, "image", "") or ""),
+            paragraphs=paragraphs,
+            blocks=blocks,
+        )
+
+
+register_article_extractor(LocalArticleExtractor())
+
+
 def _fetch_x_profile_metadata(handle: str) -> dict[str, str]:
     try:
         reader = _reader_text(f"https://x.com/{handle.lstrip('@')}")
@@ -468,7 +595,46 @@ def _extract_body(raw_html: str, extracted: ExtractedArticleContent) -> str:
     return "\n\n".join(sentence for sentence in sentences[:MAX_PARAGRAPHS] if sentence)[:MAX_BODY_CHARS]
 
 
-def fetch_article(url: str, *, extractor_name: str = "jina") -> Article:
+def _extracted_content_chars(extracted: ExtractedArticleContent) -> int:
+    """Length of the real text an extractor recovered, mirroring the validation gate."""
+    fragments = list(extracted.paragraphs or [])
+    if extracted.blocks:
+        fragments = [value for kind, value in extracted.blocks if kind != "image"]
+    combined = " ".join(part for part in fragments if part)
+    return len(re.sub(r"\s+", " ", combined).strip())
+
+
+JINA_FALLBACK_NOTE = (
+    "local extraction recovered too little content, so this article was re-fetched "
+    "through the jina remote reader (the URL was sent to the third-party r.jina.ai service)"
+)
+
+
+def _extract_with_fallback(extractor, url: str) -> tuple[ExtractedArticleContent, str]:
+    """Run the configured extractor; chain local -> jina when local comes up short.
+
+    Returns (content, note). The note is the honest record that the privacy
+    promise of `local` was traded for content on this URL — surfaced in the
+    print/stage results, never silent.
+    """
+    try:
+        extracted = extractor.extract(url)
+    except Exception:
+        if extractor.name != "local":
+            raise
+        extracted = ExtractedArticleContent()
+    if extractor.name != "local" or _extracted_content_chars(extracted) >= MIN_ARTICLE_LENGTH:
+        return extracted, ""
+    try:
+        fallback = get_article_extractor("jina").extract(url)
+    except Exception:
+        return extracted, ""
+    if _extracted_content_chars(fallback) > _extracted_content_chars(extracted):
+        return fallback, JINA_FALLBACK_NOTE
+    return extracted, ""
+
+
+def fetch_article(url: str, *, extractor_name: str = "local") -> Article:
     domain = _normalized_domain(url)
     if domain in SKIP_DOMAINS:
         raise ArticleExtractionError(
@@ -486,7 +652,7 @@ def fetch_article(url: str, *, extractor_name: str = "jina") -> Article:
             f"Could not fetch article from `{url}`. The source returned an HTTP or network error. Detail: {exc}"
         ) from exc
     raw_html = response.text
-    extracted = extractor.extract(url)
+    extracted, extraction_note = _extract_with_fallback(extractor, url)
     title = _meta_content(raw_html, "og:title")
     if not title:
         match = re.search(r"<title>(.*?)</title>", raw_html, flags=re.IGNORECASE | re.DOTALL)
@@ -539,6 +705,7 @@ def fetch_article(url: str, *, extractor_name: str = "jina") -> Article:
         views=int(fx_meta["views"]) if fx_meta.get("views") is not None else None,
         bio=str(fx_meta["bio"]).strip() if fx_meta.get("bio") else None,
         blocks=blocks,
+        extraction_note=extraction_note,
     )
 
 

--- a/src/morning_paper/cli.py
+++ b/src/morning_paper/cli.py
@@ -365,6 +365,11 @@ def print_command(args: list[str]) -> int:
         for article in articles
         if (message := article_truncation_warning(article))
     ]
+    # Honesty rule: if the local extractor fell back to the remote jina reader,
+    # say so — the reader should know this URL left the machine.
+    truncation_warnings.extend(
+        f"{article.url} {article.extraction_note}" for article in articles if article.extraction_note
+    )
     try:
         outputs, warnings, pages = write_custom_markdown(
             config,
@@ -583,6 +588,7 @@ def stage_command(args: list[str]) -> int:
             truncated=bool(report["truncated"]),
             words_extracted=int(report["words_extracted"]),
             warning=article_truncation_warning(article),
+            extractor_note=article.extraction_note,
         )
     else:
         source = Path(target).expanduser()

--- a/src/morning_paper/config.py
+++ b/src/morning_paper/config.py
@@ -54,7 +54,7 @@ class MorningPaperConfig:
     name: str = "Morning Paper"
     timezone: str = "America/Los_Angeles"
     profile: str = ""
-    article_extractor: str = "jina"
+    article_extractor: str = "local"
     page_budget: int = 20
     sources: SourcesConfig = field(default_factory=SourcesConfig)
     outputs: OutputsConfig = field(default_factory=OutputsConfig)
@@ -115,8 +115,8 @@ def _validate_palette(value: str) -> str:
 
 
 def _validate_article_extractor(value: str) -> str:
-    if value not in {"jina"}:
-        raise ConfigError("article_extractor must be one of: jina")
+    if value not in {"local", "jina"}:
+        raise ConfigError("article_extractor must be one of: local, jina")
     return value
 
 
@@ -141,7 +141,7 @@ def load_config(path: Path) -> MorningPaperConfig:
         name=str(data.get("name", "Morning Paper")),
         timezone=_validate_timezone(str(data.get("timezone", "America/Los_Angeles"))),
         profile=str(data.get("profile", "")).strip(),
-        article_extractor=_validate_article_extractor(str(data.get("article_extractor", "jina"))),
+        article_extractor=_validate_article_extractor(str(data.get("article_extractor", "local"))),
         page_budget=page_budget,
         sources=SourcesConfig(
             hacker_news=HackerNewsConfig(
@@ -195,7 +195,11 @@ timezone: {detect_system_timezone()}
 profile: |
   Add a short note about who this paper is for and what should matter most.
   Replace this with your own beat: the topics, projects, and people you follow.
-article_extractor: jina
+# article extraction for `print`/`stage`: `local` fetches and parses on this
+# machine (trafilatura) — URLs never leave your computer. `jina` sends each URL
+# to the third-party r.jina.ai reader service; it remains available and is used
+# automatically (with an honest note) when local extraction comes up short.
+article_extractor: local
 # target length for a full edition; `morning-paper queue` reports against this
 page_budget: 20
 

--- a/src/morning_paper/staging.py
+++ b/src/morning_paper/staging.py
@@ -34,6 +34,7 @@ class StagedItem:
     truncated: bool = False           # honesty flag: the staged copy is incomplete
     words_extracted: int | None = None  # words the extractor recovered before any render cap
     warning: str = ""                 # plain-language explanation when truncated
+    extractor_note: str = ""          # honesty note: e.g. local extraction fell back to jina
 
 
 def staging_dir(config: MorningPaperConfig, date_str: str) -> Path:
@@ -69,6 +70,7 @@ def stage_markdown(
     truncated: bool = False,
     words_extracted: int | None = None,
     warning: str = "",
+    extractor_note: str = "",
 ) -> StagedItem:
     sdir = staging_dir(config, date_str)
     slug = _safe_filename(title)[:48] or "staged"
@@ -95,6 +97,7 @@ def stage_markdown(
         truncated=truncated,
         words_extracted=words_extracted,
         warning=warning,
+        extractor_note=extractor_note,
     )
     queue.append(asdict(item))
     _save_queue(sdir, queue)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -161,6 +161,8 @@ class BuildFlowTest(unittest.TestCase):
             self.assertEqual(config["outputs"]["style"], "editorial")
             self.assertEqual(config["outputs"]["palette"], "color")
             self.assertEqual(config["outputs"]["renderer"], "typewriter")
+            # local-first extraction: URLs stay on this machine by default
+            self.assertEqual(config["article_extractor"], "local")
             config["outputs"]["directory"] = str(output_dir)
             config["outputs"]["renderer"] = "portable"
             config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+import requests
+import yaml
+
+from morning_paper import cli
+from morning_paper.article_print import JINA_FALLBACK_NOTE, Article, fetch_article
+from morning_paper.config import ConfigError, MorningPaperConfig, load_config, render_default_config
+from morning_paper.extractors import get_article_extractor
+
+
+RICH_ARTICLE_HTML = """
+<html>
+  <head>
+    <title>The Quiet Craft of Local Extraction — Example Journal</title>
+    <meta property="og:title" content="The Quiet Craft of Local Extraction" />
+    <meta property="og:image" content="https://example.com/images/lede.jpg" />
+    <meta property="og:site_name" content="Example Journal" />
+    <meta name="author" content="Devon Meadows" />
+  </head>
+  <body>
+    <nav><a href="/">Home</a><a href="/about">About</a></nav>
+    <article>
+      <h1>The Quiet Craft of Local Extraction</h1>
+      <p>Local extraction keeps the entire reading pipeline on the reader's own machine,
+      which means the list of articles a person cares about never becomes a log line in
+      somebody else's analytics dashboard or rate-limited queue.</p>
+      <h2>Why it matters</h2>
+      <p>The newspaper metaphor only works if the reader owns the route from source to
+      page. A third-party reader service can vanish, throttle, or change its parser, and
+      the morning ritual should not depend on any of those things going well today.</p>
+      <p>This sample body is intentionally long enough to clear the two-hundred-character
+      validation gate with room to spare, so the extractor tests exercise the same path a
+      real essay would take on a real morning, ending cleanly with a full stop.</p>
+    </article>
+    <footer>Subscribe to the newsletter.</footer>
+  </body>
+</html>
+"""
+
+THIN_ARTICLE_HTML = """
+<html>
+  <head>
+    <title>Thin Page</title>
+    <meta property="og:title" content="Thin Page" />
+    <meta property="og:site_name" content="Example" />
+    <meta name="author" content="Devon" />
+  </head>
+  <body><article><p>Almost nothing here.</p></article></body>
+</html>
+"""
+
+JINA_RICH_TEXT = (
+    "Title: Thin Page\n\n"
+    "Markdown Content:\n\n"
+    "The remote reader recovered the full body of this article even though the raw "
+    "page served almost nothing to a plain fetch without JavaScript execution.\n\n"
+    "This second paragraph pushes the fallback extraction comfortably past the "
+    "validation gate so the chained result renders as a legitimate article instead "
+    "of failing on length.\n\n"
+    "A third paragraph keeps the fallback clearly richer than the local attempt."
+)
+
+
+class _FakeResponse:
+    def __init__(self, *, text: str, status_code: int = 200, headers: dict[str, str] | None = None) -> None:
+        self.text = text
+        self.content = text.encode("utf-8")
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"http error: {self.status_code}")
+
+    def json(self) -> object:
+        return json.loads(self.text)
+
+
+def _fake_get_rich(url: str, timeout: int = 30, **kwargs: object) -> _FakeResponse:
+    if "r.jina.ai" in url:
+        raise AssertionError("local extraction succeeded; the jina remote reader must not be called")
+    return _FakeResponse(text=RICH_ARTICLE_HTML)
+
+
+def _fake_get_thin_with_jina(url: str, timeout: int = 30, **kwargs: object) -> _FakeResponse:
+    if "r.jina.ai" in url:
+        return _FakeResponse(text=JINA_RICH_TEXT)
+    return _FakeResponse(text=THIN_ARTICLE_HTML)
+
+
+class LocalExtractorTest(unittest.TestCase):
+    def test_local_extractor_parses_mocked_html(self) -> None:
+        extractor = get_article_extractor("local")
+        with patch("morning_paper.article_print.requests.get", side_effect=_fake_get_rich):
+            extracted = extractor.extract("https://example.com/essay")
+
+        self.assertEqual(extracted.title, "The Quiet Craft of Local Extraction")
+        self.assertEqual(extracted.author, "Devon Meadows")
+        self.assertEqual(extracted.image_url, "https://example.com/images/lede.jpg")
+        kinds = {kind for kind, _ in extracted.blocks}
+        self.assertIn("paragraph", kinds)
+        self.assertIn("callout", kinds)  # headings carry through as callouts
+        combined = " ".join(extracted.paragraphs)
+        self.assertIn("Local extraction keeps the entire reading pipeline", combined)
+        self.assertGreater(len(combined), 200)
+
+    def test_fetch_article_local_path_never_calls_jina(self) -> None:
+        with patch("morning_paper.article_print.requests.get", side_effect=_fake_get_rich):
+            article = fetch_article("https://example.com/essay")
+
+        self.assertEqual(article.extraction_note, "")
+        self.assertEqual(article.title, "The Quiet Craft of Local Extraction")
+        self.assertIn("Local extraction keeps the entire reading pipeline", article.body)
+
+    def test_local_falls_back_to_jina_with_honest_note(self) -> None:
+        with patch("morning_paper.article_print.requests.get", side_effect=_fake_get_thin_with_jina):
+            article = fetch_article("https://example.com/thin")
+
+        self.assertEqual(article.extraction_note, JINA_FALLBACK_NOTE)
+        self.assertIn("r.jina.ai", article.extraction_note)
+        self.assertIn("The remote reader recovered the full body", article.body)
+
+    def test_print_surfaces_fallback_note_as_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "config.yaml"
+            rc = cli.main(["init", "--config", str(config_path)])
+            self.assertEqual(rc, 0)
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            config["outputs"]["directory"] = str(tmp_path / "out")
+            config["outputs"]["renderer"] = "portable"
+            config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+            stdout = io.StringIO()
+            with patch("morning_paper.article_print.requests.get", side_effect=_fake_get_thin_with_jina):
+                with redirect_stdout(stdout):
+                    rc = cli.main(
+                        ["print", "https://example.com/thin", "--config", str(config_path), "--date", "2026-06-12"]
+                    )
+            self.assertEqual(rc, 0)
+            payload = json.loads(stdout.getvalue())
+            self.assertTrue(
+                any("r.jina.ai" in warning for warning in payload["warnings"]),
+                payload["warnings"],
+            )
+
+    def test_stage_carries_extractor_note(self) -> None:
+        article = Article(
+            url="https://example.com/thin",
+            title="Thin Page",
+            author="Devon",
+            source_name="Example",
+            body="",
+            blocks=[("paragraph", "A complete sentence that stands in for staged article content.")],
+            extraction_note=JINA_FALLBACK_NOTE,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "config.yaml"
+            rc = cli.main(["init", "--config", str(config_path)])
+            self.assertEqual(rc, 0)
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            config["outputs"]["directory"] = str(tmp_path / "out")
+            config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
+
+            stdout = io.StringIO()
+            with patch("morning_paper.cli.fetch_article", return_value=article):
+                with redirect_stdout(stdout):
+                    rc = cli.main(
+                        ["stage", article.url, "--config", str(config_path), "--date", "2026-06-12"]
+                    )
+            self.assertEqual(rc, 0)
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual(payload["extractor_note"], JINA_FALLBACK_NOTE)
+
+
+class ExtractorConfigTest(unittest.TestCase):
+    def test_local_is_the_default_extractor(self) -> None:
+        self.assertEqual(MorningPaperConfig().article_extractor, "local")
+        self.assertIn("article_extractor: local", render_default_config())
+
+    def test_default_config_loads_with_local_extractor(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(render_default_config(), encoding="utf-8")
+            data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            data["outputs"]["directory"] = str(tmp_path / "out")
+            config_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+            config = load_config(config_path)
+            self.assertEqual(config.article_extractor, "local")
+
+    def test_config_accepts_jina_and_rejects_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            config_path = tmp_path / "config.yaml"
+            base = yaml.safe_load(render_default_config())
+            base["outputs"]["directory"] = str(tmp_path / "out")
+
+            base["article_extractor"] = "jina"
+            config_path.write_text(yaml.safe_dump(base, sort_keys=False), encoding="utf-8")
+            self.assertEqual(load_config(config_path).article_extractor, "jina")
+
+            base["article_extractor"] = "telepathy"
+            config_path.write_text(yaml.safe_dump(base, sort_keys=False), encoding="utf-8")
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(config_path)
+            self.assertIn("local, jina", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

Implements the two binding owner rulings for 0.4.2.

### Task 1 — local-first article extraction (de-SaaS the default)

- **New `local` extractor** (`src/morning_paper/article_print.py`): fetches the URL directly with `requests` (browser UA, 30s timeout) and parses with **trafilatura** (markdown output), mapped into the existing block vocabulary (`paragraph`/`blockquote`/`callout`/`image`). The validation gate, truncation reporting, image pipeline, and renderer work identically on both extraction paths.
- **Dependency decision: core.** trafilatura is a plain `dependencies` entry (`>=1.12`), not an extra. The morning-paper wheel grows only ~2.5 KB; the dependency tree adds ~20 MB of wheels (lxml + babel dominate; certifi/charset-normalizer/urllib3 are already in the tree via requests). Acceptable for a desktop print CLI that already wants Pango + WeasyPrint, and it means the privacy default actually works out of the box.
- **`local` is the default** in `MorningPaperConfig`, `load_config`, `render_default_config` (with the privacy trade documented in a starter-config comment), and `fetch_article`'s signature. `jina` stays registered and selectable.
- **Honest fallback chain `local -> jina`:** when local extraction recovers less than the validation threshold, the jina retry runs and the result carries an explicit note that the URL was sent to the third-party `r.jina.ai` service — as `Article.extraction_note`, a `print` warning line, and a new `extractor_note` field in the stage JSON/queue. Never silent.
- Privacy note stated plainly in README (For Agents + Rendering), `docs/composing.md` (new extraction section), `docs/architecture-decisions.md` (dated amendments, original decisions preserved), ROADMAP, and `examples/config.example.yaml`.

### Task 2 — "Set up with AI (recommended)"

- Copy-paste onboarding prompt at the very top of the README (right after the hero, before Try it), in a fenced block so GitHub shows a copy button: read the README, explore the architecture, interview the reader, install, `doctor`, `demo`, private newsroom repo, first printed edition, daily loop including the desk sheet.
- Shorter pointer mirrored at the head of the **For Agents** section.

### Release plumbing

- Version 0.4.2 in `pyproject.toml`, `__init__.py`, `.claude-plugin/plugin.json`
- CHANGELOG entry (Added: local extractor default + AI setup prompt + `extractor_note`; Changed: jina demoted to fallback with privacy note)

## Verification

- `python3 -m pytest tests/ -q` → **40 passed** (32 baseline + 8 new in `tests/test_extractors.py`: mocked-HTML extraction, no-jina-call-on-success, fallback note at fetch/print/stage level, default-config and validation assertions)
- Live smoke test: `fetch_article` on a real essay extracted title/author/48 blocks with images via the local path, `extraction_note == ""` (no jina call)
- `morning-paper doctor` → typewriter ready; `--version` → 0.4.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)