### PR TITLE
The contributor inbox: your masthead can email the paper (0.4.4)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-paper",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Your personal newsroom: a daily printed paper composed by your agent from your sources, with preferences you own as files.",
   "author": { "name": "Devon Meadows", "url": "https://github.com/dmthepm" },
   "homepage": "https://github.com/dmthepm/morning-paper",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-06-11
+
+### Added
+- **The contributor inbox ("the masthead")**: people the reader trusts email articles in and they land in tomorrow's staging queue — `morning-paper inbox` (alias `inbox poll`) polls a mailbox over IMAP, stdlib only. New top-level `inbox:` config block: `enabled` (default false), `imap_host`/`imap_user`, `mailbox`, optional `subject_tag` filter (default `paper`), `reply`, optional `smtp_host`/`smtp_user` (derived from the IMAP values when omitted), and `contributors:` — the masthead, a strict `{email, name}` allowlist that is required non-empty when enabled and is THE gate: mail from anyone else is skipped and reported, never staged
+- Passwords never go in config: the credential comes from `MORNING_PAPER_IMAP_PASSWORD` (and `MORNING_PAPER_SMTP_PASSWORD` when distinct), and the config loader rejects any `password` key in the inbox block with the fix in the error. Gmail/iCloud app-password walkthrough in the new [docs/inbox.md](docs/inbox.md), including the plus-addressing tip and the one-sentence contributor onboarding
+- A link in the mail body stages through the same path as `stage <url>` (new shared `staging.stage_url` helper — same extractor, same honest truncation flags); a mail with no link stages as kind `note`. The staged item records `contributor: <name>`, and build editions render contributor items with a FROM <NAME> kicker
+- Warm confirmation reply from the reader's own address when something stages ("Got it — this is in Morning Paper tomorrow morning (about N pages). ☕" — with the real page estimate); `reply: false` turns it off
+- `inbox --dry-run` reports what WOULD stage without staging, replying, or marking mail read. Safety rules either way: messages are fetched with BODY.PEEK and marked Seen only after a successful stage; one bad message never crashes the poll (it lands in `skipped` with a reason); HTML-only payloads are stripped of script/style and tags — all mail content is treated as untrusted text
+- `setup` skill now interviews for the masthead (who can feed the paper, app-password setup, the sentence to send contributors); `edition` skill polls the inbox before composing
+
 ## [0.4.3] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ newsroom repo, first edition, daily loop). Otherwise:
 3. The CLI speaks JSON. The verbs you need:
    - `morning-paper stage <url>` -> stages it for tomorrow and answers with a
      page estimate ("that adds ~5 pages")
+   - `morning-paper inbox` -> poll the contributor inbox: mail from the
+     configured masthead (an allowlist of trusted senders) becomes staged
+     pages and the sender gets a confirmation; `--dry-run` previews
+     ([docs/inbox.md](docs/inbox.md))
    - `morning-paper queue` -> what's staged vs the page budget
    - `morning-paper estimate <file.md>` -> page count, nothing written
    - `morning-paper render <file.md> --style <s> --palette <p>` -> the PDF
@@ -216,6 +220,8 @@ shipping something worse. The paper never lies to you about what it knows.
 
 - [docs/composing.md](docs/composing.md) — the composition contract for agents:
   document structure, class vocabulary, chart directives
+- [docs/inbox.md](docs/inbox.md) — the contributor inbox: let people you
+  trust email articles into tomorrow's paper (Gmail/iCloud app-password setup)
 - [ROADMAP.md](ROADMAP.md) — what shipped, what's next
 - [CHANGELOG.md](CHANGELOG.md) — release history
 - [CONTRIBUTING.md](CONTRIBUTING.md) — how to help

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,6 +38,12 @@
   auto-fallback with a privacy note in the result
 - "Set up with AI" onboarding prompt at the top of the README
 
+## Shipped (`v0.4.4`)
+
+- the contributor inbox ("the masthead") — `morning-paper inbox` polls a
+  mailbox over IMAP; trusted senders' mail becomes staged pages with a
+  FROM <NAME> kicker and a warm confirmation reply (docs/inbox.md)
+
 ## Next (`v0.4`)
 
 - queue management verbs: `morning-paper remove`, `morning-paper list`
@@ -50,6 +56,8 @@
 
 ## Future
 
+- a hosted contributor door (Cloudflare Worker email address) for instant
+  confirmations — today's path is the IMAP poll
 - preference learning
 - shared community curation and page exchange
 - agent slot competition against a page budget

--- a/docs/inbox.md
+++ b/docs/inbox.md
@@ -1,0 +1,148 @@
+# The contributor inbox — "the masthead"
+
+People you trust email you articles; they land in tomorrow's staging queue;
+the sender gets a warm confirmation back. Your spouse, your co-founder, your
+group chat's designated finder-of-things — they become contributors to your
+paper, and the paper says so in print: staged contributor items carry a
+**FROM SAM** kicker.
+
+No webhook, no service, no new dependency. `morning-paper inbox` polls a
+mailbox over IMAP (stdlib only), stages what the masthead sent, and replies
+from your own address.
+
+## The sentence to send your contributors
+
+Once it's set up, the entire onboarding for a contributor is one sentence:
+
+> See something I should read? Email it to me with "paper" in the subject — it'll be on my desk tomorrow morning.
+
+That's it. They email a link (or just a note — notes stage too), and the next
+edition carries it with their name on the kicker.
+
+## Quick start
+
+1. Add the block to `~/.config/morning-paper/config.yaml`:
+
+```yaml
+inbox:
+  enabled: true
+  imap_host: imap.gmail.com        # or imap.mail.me.com for iCloud
+  imap_user: you@gmail.com
+  mailbox: INBOX
+  # only mail whose subject contains this word is staged; set "" to take all
+  subject_tag: paper
+  # THE MASTHEAD — the allowlist. Mail from anyone else is never staged.
+  contributors:
+    - email: someone-you-trust@example.com
+      name: Sam
+  # send a warm confirmation back from your own address when something stages
+  reply: true
+  # smtp_host/smtp_user default to the imap values (imap.* host becomes smtp.*)
+```
+
+2. Set the password in the environment — **never in config**:
+
+```bash
+export MORNING_PAPER_IMAP_PASSWORD="your-app-password"
+```
+
+(If your SMTP credential differs from IMAP, also set
+`MORNING_PAPER_SMTP_PASSWORD`.) Put the export in
+`~/.config/morning-paper/env.sh` alongside any other credentials, and source
+it from the shell or scheduled job that runs the poll. A config file
+containing any `password` key is rejected with an error pointing here.
+
+3. Preview without touching anything:
+
+```bash
+morning-paper inbox --dry-run
+```
+
+4. Poll for real:
+
+```bash
+morning-paper inbox        # alias: morning-paper inbox poll
+```
+
+JSON out:
+
+```json
+{
+  "edition_date": "2026-06-12",
+  "dry_run": false,
+  "polled": 3,
+  "staged": [ { "slug": "...", "kind": "url", "contributor": "Sam", "est_pages": 4, ... } ],
+  "replied": 1,
+  "skipped": [ { "from": "stranger@example.com", "reason": "not on the masthead" } ],
+  "warnings": []
+}
+```
+
+## App passwords
+
+Your normal account password will not work (and should never be typed into a
+config-adjacent shell anyway). Both major providers issue scoped app
+passwords:
+
+**Gmail**
+1. Turn on 2-Step Verification (required): myaccount.google.com → Security.
+2. Create an app password: [myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords)
+   — name it `morning-paper`, copy the 16-character password.
+3. Hosts: `imap_host: imap.gmail.com` (SMTP `smtp.gmail.com` is derived
+   automatically).
+
+**iCloud**
+1. Sign in at [account.apple.com](https://account.apple.com) → Sign-In and
+   Security → App-Specific Passwords → generate one named `morning-paper`.
+2. Hosts: `imap_host: imap.mail.me.com` (SMTP `smtp.mail.me.com` is derived
+   automatically). `imap_user` is your full iCloud address.
+
+## Keeping it tidy: plus-addressing
+
+If you'd rather not poll your whole inbox, give contributors a plus address —
+`you+paper@gmail.com` works without any setup (Gmail and iCloud both deliver
+plus-addressed mail to the same account). Then add a filter that labels
+those messages (Gmail labels are IMAP mailboxes) and point the poll at it:
+
+```yaml
+mailbox: paper        # the Gmail label / IMAP folder your filter applies
+```
+
+With a dedicated mailbox you can also set `subject_tag: ""` — the address is
+the filter, so the subject no longer needs the magic word.
+
+## What gets staged
+
+- **A link** — the first `http(s)` URL in the body is fetched and staged
+  exactly like `morning-paper stage <url>`: same extractor, same honest
+  truncation flags, same page estimate. Subject (minus the tag) becomes the
+  title override.
+- **Just a note** — no URL means the mail body stages as a `note`: your
+  contributor can send two paragraphs about the garden and it prints.
+- Either way the staged item records `contributor: <name>`, and editions
+  render it with a FROM <NAME> kicker.
+
+The sender's confirmation (when `reply: true`) is short and warm, sent from
+your own address: *"Got it — this is in Morning Paper tomorrow morning
+(about 4 pages). ☕"*
+
+## The security model, stated plainly
+
+- **The masthead is the gate.** Mail from any sender not on the
+  `contributors` list is skipped and reported in the JSON — never staged, no
+  matter what the subject or body says.
+- **All mail content is untrusted text.** HTML-only messages have script and
+  style blocks removed and every tag stripped before anything is read from
+  them; nothing from a mail is ever executed or rendered as live HTML.
+- **Seen only on success.** A message is marked read only after its content
+  staged. A failed extraction or a crashed poll leaves the mail unread for
+  the next attempt — and one bad message never takes down the poll; it lands
+  in `skipped` with a reason.
+- **No passwords in config.** The credential lives in the environment, and
+  the config loader rejects any `password` key in the inbox block.
+
+## In the morning routine
+
+The `edition` skill runs `morning-paper inbox` before composing, so anything
+the masthead sent overnight is in the queue by the time the editor reads it.
+Running it again is always safe: only unread mail is considered.

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -32,3 +32,23 @@ outputs:
   html: true
   markdown: true
   json: true
+
+# the contributor inbox ("the masthead"): people you trust email you articles
+# and they land in tomorrow's staging queue. `contributors` is an allowlist —
+# mail from anyone else is never staged. Your mail password NEVER goes in this
+# file: set the MORNING_PAPER_IMAP_PASSWORD environment variable to an app
+# password (Gmail/iCloud walkthrough: docs/inbox.md).
+inbox:
+  enabled: false
+  imap_host: imap.example.com
+  imap_user: you@example.com
+  mailbox: INBOX
+  # only mail whose subject contains this word is staged; set "" to take all
+  subject_tag: paper
+  # the masthead — who is allowed to feed your paper
+  contributors:
+    - email: someone-you-trust@example.com
+      name: Sam
+  # send a warm confirmation back from your own address when something stages
+  reply: true
+  # smtp_host/smtp_user default to the imap values (imap.* host becomes smtp.*)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.4.3"
+version = "0.4.4"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/edition/SKILL.md
+++ b/skills/edition/SKILL.md
@@ -15,10 +15,14 @@ paper.
 
 ## The pass
 
-1. **Collect.** Run the user's collectors (newsroom `collectors/`, or the
-   engine's `morning-paper build` for HN/RSS). Check the staged queue:
-   `morning-paper queue` — anything staged via `stage` belongs in today's
-   paper (a human or another agent put it there on purpose).
+1. **Collect.** If the contributor inbox is configured, poll it first:
+   `morning-paper inbox` — mail from the masthead becomes staged items and
+   the senders get their confirmations. Then run the user's collectors
+   (newsroom `collectors/`, or the engine's `morning-paper build` for
+   HN/RSS). Check the staged queue: `morning-paper queue` — anything staged
+   via `stage` or the inbox belongs in today's paper (a human or another
+   agent put it there on purpose). Staged items with a `contributor` name
+   render with a FROM <NAME> kicker — the paper says who sent it in.
 2. **Read the newsroom.** `specs/*` (section contracts) and `preferences/*`
    (reading weights, style notes). These outrank your taste.
 3. **Compose** one markdown document (raw HTML allowed; see the engine's

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -46,7 +46,35 @@ Write their answers into `~/.config/morning-paper/config.yaml`.
 - **gh CLI**: a "shipped while you slept" section from their repos.
 Each missing unlock = a section that prints "not configured", never fake data.
 
-## 4. The newsroom repo (the owned algorithm)
+## 4. The masthead (the contributor inbox)
+
+Ask: **who should be able to feed this paper?** A spouse, a co-founder, the
+one friend who always finds the good stuff — people whose mail should become
+pages. If the answer is "nobody yet", skip; the block ships disabled.
+
+If yes:
+- Add the `inbox:` block to config.yaml (see docs/inbox.md): `enabled: true`,
+  their mail provider's `imap_host`/`imap_user`, and `contributors:` — the
+  masthead, a strict allowlist of `{email, name}`. Mail from anyone else is
+  never staged.
+- The password is an **app password**, never the account password and never
+  in config: Gmail at myaccount.google.com/apppasswords (needs 2-Step
+  Verification; host `imap.gmail.com`), iCloud at account.apple.com →
+  Sign-In and Security → App-Specific Passwords (host `imap.mail.me.com`).
+  Store it as `MORNING_PAPER_IMAP_PASSWORD` in
+  `~/.config/morning-paper/env.sh` like the other credentials.
+- Verify with `morning-paper inbox --dry-run`, then have the user send
+  themselves a test mail with "paper" in the subject and poll for real.
+- Give the user the sentence to send each contributor: *"See something I
+  should read? Email it to me with \"paper\" in the subject — it'll be on my
+  desk tomorrow morning."* Tip: a plus address (`you+paper@gmail.com`) plus
+  a label/filter keeps the poll out of their main inbox (docs/inbox.md).
+- Upsell, honestly labeled: a hosted door (Cloudflare Worker email address)
+  for **instant** confirmations instead of poll-time ones is on the roadmap —
+  **not yet shipped**. Today's path is the IMAP poll, which the edition skill
+  runs every morning anyway.
+
+## 5. The newsroom repo (the owned algorithm)
 
 Create a PRIVATE repo (suggest `<user>/newsroom`) with:
 ```
@@ -58,13 +86,13 @@ collectors/   # any custom source scripts
 Explain the point in one line: *your feed has an algorithm you can't see;
 your paper's algorithm is files you can read and edit.*
 
-## 5. The morning routine
+## 6. The morning routine
 
 Offer to schedule it (Claude scheduled tasks / cron): every morning run the
 `edition` skill of this plugin. If they prefer manual, the command is just
 invoking `/morning-paper:edition`.
 
-## 6. First edition, now
+## 7. First edition, now
 
 Run the edition skill once end-to-end while they watch. Print it if the
 printer is ready. Hand them the paper. Done is a physical object.

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"

--- a/src/morning_paper/cli.py
+++ b/src/morning_paper/cli.py
@@ -12,7 +12,6 @@ import requests
 
 from .article_print import (
     ArticleExtractionError,
-    article_truncation_report,
     article_truncation_warning,
     fetch_article,
     render_article_markdown,
@@ -42,6 +41,8 @@ Commands:
   print <url>       Print a single article right now
   render <file.md>  Typeset any markdown file through a style pack
   stage <url|file>  Queue material for tomorrow's paper (returns a page estimate)
+  inbox             Poll the contributor inbox: mail from your masthead becomes
+                    staged pages, the sender gets a confirmation (--dry-run)
   queue             Show what's staged vs the page budget (JSON)
   estimate <file>   Page count for a markdown file, nothing written
   styles            List available styles and palettes
@@ -131,6 +132,7 @@ def doctor(args: list[str] | None = None) -> int:
         "morning_paper.config",
         "morning_paper.extractors",
         "morning_paper.image_tools",
+        "morning_paper.inbox",
         "morning_paper.renderers",
         "morning_paper.sources",
     ]
@@ -611,7 +613,7 @@ def _parse_common(args: list[str], usage: str) -> tuple[Path, str | None, list[s
 
 
 def stage_command(args: list[str]) -> int:
-    from .staging import default_edition_date, stage_markdown
+    from .staging import default_edition_date, stage_markdown, stage_url
 
     usage = "usage: morning-paper stage <url|file.md> [--title T] [--date YYYY-MM-DD] [--config PATH]"
     title_override = None
@@ -635,28 +637,13 @@ def stage_command(args: list[str]) -> int:
         return 1
     date_str = date or default_edition_date(config)
     if target.startswith("http://") or target.startswith("https://"):
+        # the one URL-staging path, shared with the contributor inbox — the
+        # honesty flags (truncation, extractor fallback) ride along in the JSON
         try:
-            article = fetch_article(target, extractor_name=config.article_extractor)
+            item = stage_url(config, target, date_str=date_str, title=title_override)
         except ArticleExtractionError as exc:
             print(json.dumps({"staged": False, "error": str(exc)}, indent=2))
             return 1
-        markdown = render_article_markdown(
-            config,
-            [article],
-            date_str=date_str,
-            images_dir=config.outputs.directory / "staging" / date_str / "_images",
-        )
-        # Honesty rule: if extraction or the render cap clipped the article,
-        # say so plainly in the JSON instead of staging silently.
-        report = article_truncation_report(article)
-        item = stage_markdown(
-            config, markdown, date_str=date_str, kind="url", source=target,
-            title=title_override or article.title,
-            truncated=bool(report["truncated"]),
-            words_extracted=int(report["words_extracted"]),
-            warning=article_truncation_warning(article),
-            extractor_note=article.extraction_note,
-        )
     else:
         source = Path(target).expanduser()
         if not source.is_file():
@@ -670,6 +657,39 @@ def stage_command(args: list[str]) -> int:
 
     payload = {"staged": True, "edition_date": date_str, **asdict(item)}
     print(json.dumps(payload, indent=2))
+    return 0
+
+
+def inbox_command(args: list[str]) -> int:
+    from .inbox import InboxError, poll_inbox
+
+    usage = "usage: morning-paper inbox [poll] [--dry-run] [--date YYYY-MM-DD] [--config PATH]"
+    dry_run = False
+    if "--dry-run" in args:
+        dry_run = True
+        args = [arg for arg in args if arg != "--dry-run"]
+    parsed = _parse_common(args, usage)
+    if isinstance(parsed, int):
+        return parsed
+    config_path, date, rest = parsed
+    if rest == ["poll"]:
+        rest = []
+    if rest:
+        print(usage, file=sys.stderr)
+        return 2
+    try:
+        config, _ = _load_print_config(config_path)
+    except ConfigError as exc:
+        print(f"invalid config: {exc}", file=sys.stderr)
+        return 1
+    try:
+        result = poll_inbox(config, dry_run=dry_run, date_str=date)
+    except InboxError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    for warning in result.get("warnings", []):
+        print(f"warning: {warning}", file=sys.stderr)
+    print(json.dumps(result, indent=2))
     return 0
 
 
@@ -771,6 +791,8 @@ def main(argv: list[str] | None = None) -> int:
         return render_command(extra)
     if command in {"stage", "add"}:
         return stage_command(extra)
+    if command == "inbox":
+        return inbox_command(extra)
     if command in {"queue", "status"}:
         return queue_command(extra)
     if command == "estimate":

--- a/src/morning_paper/config.py
+++ b/src/morning_paper/config.py
@@ -37,6 +37,36 @@ class SourcesConfig:
 
 
 @dataclass(slots=True)
+class ContributorConfig:
+    email: str
+    name: str = ""
+
+
+@dataclass(slots=True)
+class InboxConfig:
+    """The contributor inbox — "the masthead".
+
+    People the reader trusts email articles; they land in tomorrow's staging
+    queue. The contributors list is an allowlist and the only gate: mail from
+    anyone else is never staged. The IMAP password is NEVER stored in config —
+    it is read from the MORNING_PAPER_IMAP_PASSWORD environment variable
+    (MORNING_PAPER_SMTP_PASSWORD when the reply credential is distinct).
+    """
+
+    enabled: bool = False
+    imap_host: str = ""
+    imap_user: str = ""
+    mailbox: str = "INBOX"
+    # only mail whose subject contains this tag is staged; "" disables the filter
+    subject_tag: str = "paper"
+    contributors: list[ContributorConfig] = field(default_factory=list)
+    reply: bool = True
+    # for confirmations; default derived from the imap values when omitted
+    smtp_host: str = ""
+    smtp_user: str = ""
+
+
+@dataclass(slots=True)
 class OutputsConfig:
     directory: Path = DEFAULT_OUTPUT_DIR
     renderer: str = "typewriter"
@@ -60,6 +90,7 @@ class MorningPaperConfig:
     page_budget: int = 20
     sources: SourcesConfig = field(default_factory=SourcesConfig)
     outputs: OutputsConfig = field(default_factory=OutputsConfig)
+    inbox: InboxConfig = field(default_factory=InboxConfig)
 
 
 def _expand_path(raw: str | Path | None, *, default: Path) -> Path:
@@ -132,6 +163,47 @@ def _validate_article_extractor(value: str) -> str:
     return value
 
 
+def _parse_inbox(data: dict) -> InboxConfig:
+    # Security rule: credentials never live in config. Catch any attempt early
+    # with the fix in the error, instead of silently ignoring a secret on disk.
+    for key in data:
+        if "password" in str(key).lower():
+            raise ConfigError(
+                f"inbox.{key}: passwords never go in config — "
+                "set the MORNING_PAPER_IMAP_PASSWORD environment variable instead (see docs/inbox.md)"
+            )
+    contributors = []
+    for raw in data.get("contributors") or []:
+        if not isinstance(raw, dict) or not raw.get("email"):
+            raise ConfigError("inbox.contributors entries must be {email, name} mappings")
+        contributors.append(
+            ContributorConfig(email=str(raw["email"]).strip(), name=str(raw.get("name", "")).strip())
+        )
+    raw_tag = data.get("subject_tag", "paper")
+    inbox = InboxConfig(
+        enabled=bool(data.get("enabled", False)),
+        imap_host=str(data.get("imap_host", "")).strip(),
+        imap_user=str(data.get("imap_user", "")).strip(),
+        mailbox=str(data.get("mailbox", "INBOX")).strip() or "INBOX",
+        subject_tag=str(raw_tag).strip() if raw_tag is not None else "",
+        contributors=contributors,
+        reply=bool(data.get("reply", True)),
+        smtp_host=str(data.get("smtp_host", "")).strip(),
+        smtp_user=str(data.get("smtp_user", "")).strip(),
+    )
+    if inbox.enabled:
+        if not inbox.imap_host:
+            raise ConfigError("inbox.imap_host is required when inbox.enabled is true")
+        if not inbox.imap_user:
+            raise ConfigError("inbox.imap_user is required when inbox.enabled is true")
+        if not inbox.contributors:
+            raise ConfigError(
+                "inbox.contributors must list at least one {email, name} when inbox.enabled is true — "
+                "the masthead is the allowlist; without it nothing may stage"
+            )
+    return inbox
+
+
 def load_config(path: Path) -> MorningPaperConfig:
     data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     sources = data.get("sources") or {}
@@ -175,6 +247,7 @@ def load_config(path: Path) -> MorningPaperConfig:
             markdown=bool(outputs.get("markdown", True)),
             json=bool(outputs.get("json", True)),
         ),
+        inbox=_parse_inbox(data.get("inbox") or {}),
     )
 
 
@@ -242,4 +315,24 @@ outputs:
   html: true
   markdown: true
   json: true
+
+# the contributor inbox ("the masthead"): people you trust email you articles
+# and they land in tomorrow's staging queue. `contributors` is an allowlist —
+# mail from anyone else is never staged. Your mail password NEVER goes in this
+# file: set the MORNING_PAPER_IMAP_PASSWORD environment variable to an app
+# password (Gmail/iCloud walkthrough: docs/inbox.md).
+inbox:
+  enabled: false
+  imap_host: imap.example.com
+  imap_user: you@example.com
+  mailbox: INBOX
+  # only mail whose subject contains this word is staged; set "" to take all
+  subject_tag: paper
+  # the masthead — who is allowed to feed your paper
+  contributors:
+    - email: someone-you-trust@example.com
+      name: Sam
+  # send a warm confirmation back from your own address when something stages
+  reply: true
+  # smtp_host/smtp_user default to the imap values (imap.* host becomes smtp.*)
 """

--- a/src/morning_paper/inbox.py
+++ b/src/morning_paper/inbox.py
@@ -1,0 +1,298 @@
+"""The contributor inbox — "the masthead".
+
+People the reader trusts email articles in; they land in tomorrow's staging
+queue; the sender gets a warm confirmation back. Stdlib only: imaplib,
+smtplib, email — no new dependencies, no webhook, no service.
+
+Security model, stated plainly:
+- The `inbox.contributors` allowlist is THE gate. Mail from any other sender
+  is skipped and reported, never staged — regardless of subject or content.
+- Every message body is treated as untrusted text. HTML payloads have their
+  script/style blocks removed and all tags stripped before anything is read
+  from them; nothing from a mail is ever executed or rendered as live HTML.
+- The mail password is NEVER in config. It comes from the
+  MORNING_PAPER_IMAP_PASSWORD environment variable (and
+  MORNING_PAPER_SMTP_PASSWORD when the reply credential is distinct).
+- A message is marked Seen ONLY after its content staged successfully, so a
+  failed poll leaves the mail unread for the next attempt.
+"""
+
+from __future__ import annotations
+
+import html as html_lib
+import imaplib
+import os
+import re
+import smtplib
+from dataclasses import asdict
+from email import message_from_bytes, policy
+from email.message import EmailMessage
+from email.utils import parseaddr
+
+from .article_print import ArticleExtractionError
+from .config import InboxConfig, MorningPaperConfig
+from .staging import default_edition_date, stage_markdown, stage_url
+
+
+IMAP_PASSWORD_ENV = "MORNING_PAPER_IMAP_PASSWORD"
+SMTP_PASSWORD_ENV = "MORNING_PAPER_SMTP_PASSWORD"
+
+_URL_RE = re.compile(r"https?://[^\s<>\"'\)\]]+")
+_SCRIPT_STYLE_RE = re.compile(r"<\s*(script|style)\b.*?<\s*/\s*\1\s*>", re.IGNORECASE | re.DOTALL)
+_TAG_RE = re.compile(r"<[^>]+>")
+_REPLY_PREFIX_RE = re.compile(r"^\s*(re|fwd?)\s*:\s*", re.IGNORECASE)
+
+
+class InboxError(RuntimeError):
+    pass
+
+
+def derive_smtp_host(imap_host: str) -> str:
+    """imap.gmail.com -> smtp.gmail.com; imap.mail.me.com -> smtp.mail.me.com.
+
+    The common providers follow the imap./smtp. naming convention; anything
+    that does not can set `inbox.smtp_host` explicitly.
+    """
+    if imap_host.startswith("imap."):
+        return "smtp." + imap_host[len("imap."):]
+    return imap_host
+
+
+def _strip_html(raw: str) -> str:
+    """Reduce an HTML payload to untrusted plain text — scripts gone first."""
+    text = _SCRIPT_STYLE_RE.sub(" ", raw)
+    text = _TAG_RE.sub(" ", text)
+    text = html_lib.unescape(text)
+    return re.sub(r"[ \t]+", " ", text).strip()
+
+
+def _message_text(msg) -> str:
+    """Best plain-text reading of a message; HTML-only mail is stripped to text."""
+    plain_parts: list[str] = []
+    html_parts: list[str] = []
+    for part in msg.walk():
+        if part.is_multipart():
+            continue
+        content_type = part.get_content_type()
+        if content_type not in {"text/plain", "text/html"}:
+            continue  # attachments and anything exotic are ignored, not parsed
+        try:
+            payload = part.get_content()
+        except Exception:
+            continue
+        if not isinstance(payload, str):
+            continue
+        if content_type == "text/plain":
+            plain_parts.append(payload)
+        else:
+            html_parts.append(payload)
+    if plain_parts:
+        return "\n\n".join(plain_parts).strip()
+    if html_parts:
+        # URLs often live only in href attributes; keep them findable by
+        # scanning the de-scripted source before tags are stripped.
+        descripted = " ".join(_SCRIPT_STYLE_RE.sub(" ", part) for part in html_parts)
+        text = _strip_html(" ".join(html_parts))
+        url = _URL_RE.search(descripted)
+        if url and not _URL_RE.search(text):
+            text = f"{url.group(0)}\n\n{text}"
+        return text
+    return ""
+
+
+def extract_first_url(text: str) -> str:
+    match = _URL_RE.search(text)
+    return match.group(0).rstrip(".,;") if match else ""
+
+
+def _clean_subject(subject: str, tag: str) -> str:
+    cleaned = subject
+    while _REPLY_PREFIX_RE.match(cleaned):
+        cleaned = _REPLY_PREFIX_RE.sub("", cleaned, count=1)
+    if tag:
+        cleaned = re.sub(rf"\[\s*{re.escape(tag)}\s*\]", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(rf"(?i)\b{re.escape(tag)}\b", "", cleaned, count=1)
+    return cleaned.strip(" -—:\t")
+
+
+def _est_pages_phrase(pages: int) -> str:
+    return "about 1 page" if pages <= 1 else f"about {pages} pages"
+
+
+def reply_body(config: MorningPaperConfig, est_pages: int) -> str:
+    return (
+        f"Got it — this is in {config.name} tomorrow morning "
+        f"({_est_pages_phrase(est_pages)}). ☕"
+    )
+
+
+def _send_replies(config: MorningPaperConfig, replies: list[dict]) -> tuple[int, list[str]]:
+    """One SMTP session for all confirmations; failures warn, never crash."""
+    inbox = config.inbox
+    smtp_host = inbox.smtp_host or derive_smtp_host(inbox.imap_host)
+    smtp_user = inbox.smtp_user or inbox.imap_user
+    password = os.environ.get(SMTP_PASSWORD_ENV) or os.environ.get(IMAP_PASSWORD_ENV, "")
+    sent = 0
+    warnings: list[str] = []
+    try:
+        with smtplib.SMTP_SSL(smtp_host) as smtp:
+            smtp.login(smtp_user, password)
+            for entry in replies:
+                message = EmailMessage()
+                message["From"] = smtp_user
+                message["To"] = entry["to"]
+                subject = entry.get("subject") or ""
+                message["Subject"] = f"Re: {subject}" if subject else f"Got it — {config.name}"
+                message.set_content(reply_body(config, int(entry["est_pages"])))
+                try:
+                    smtp.send_message(message)
+                    sent += 1
+                except Exception as exc:
+                    warnings.append(f"reply to {entry['to']} failed: {exc}")
+    except Exception as exc:
+        warnings.append(
+            f"could not send confirmations via {smtp_host}: {exc} "
+            "(staged items are unaffected)"
+        )
+    return sent, warnings
+
+
+def poll_inbox(
+    config: MorningPaperConfig,
+    *,
+    dry_run: bool = False,
+    date_str: str | None = None,
+) -> dict:
+    """Poll the contributor inbox; stage what the masthead sent.
+
+    Returns {polled, staged, replied, skipped, ...}. One bad message never
+    crashes the poll — it lands in `skipped` with a reason and stays unread.
+    With dry_run, nothing is staged, replied to, or marked Seen; `staged`
+    reports what WOULD stage.
+    """
+    inbox: InboxConfig = config.inbox
+    if not inbox.enabled:
+        raise InboxError(
+            "the contributor inbox is not configured: set `inbox.enabled: true` with "
+            "imap_host, imap_user, and a contributors masthead in config.yaml (see docs/inbox.md)"
+        )
+    masthead = {c.email.lower(): (c.name or c.email) for c in inbox.contributors if c.email}
+    if not masthead:
+        raise InboxError("inbox.contributors is empty — the masthead is the allowlist; nothing can stage")
+    password = os.environ.get(IMAP_PASSWORD_ENV, "")
+    if not password:
+        raise InboxError(
+            f"set the {IMAP_PASSWORD_ENV} environment variable to your mail app password "
+            "(passwords never go in config; see docs/inbox.md)"
+        )
+    edition_date = date_str or default_edition_date(config)
+    result: dict = {
+        "edition_date": edition_date,
+        "dry_run": dry_run,
+        "polled": 0,
+        "staged": [],
+        "replied": 0,
+        "skipped": [],
+        "warnings": [],
+    }
+    replies: list[dict] = []
+    conn = imaplib.IMAP4_SSL(inbox.imap_host)
+    try:
+        conn.login(inbox.imap_user, password)
+        conn.select(inbox.mailbox)
+        status, data = conn.search(None, "UNSEEN")
+        if status != "OK":
+            raise InboxError(f"IMAP search failed on {inbox.imap_host}/{inbox.mailbox}: {status}")
+        message_ids = data[0].split() if data and data[0] else []
+        for msg_id in message_ids:
+            result["polled"] += 1
+            try:
+                _process_message(
+                    conn, msg_id, config, masthead,
+                    edition_date=edition_date, dry_run=dry_run,
+                    result=result, replies=replies,
+                )
+            except Exception as exc:  # never let one bad message kill the poll
+                result["skipped"].append({"from": "", "reason": f"unreadable message: {exc}"})
+    finally:
+        try:
+            conn.logout()
+        except Exception:
+            pass
+    if replies and inbox.reply and not dry_run:
+        sent, warnings = _send_replies(config, replies)
+        result["replied"] = sent
+        result["warnings"].extend(warnings)
+    return result
+
+
+def _process_message(
+    conn,
+    msg_id: bytes,
+    config: MorningPaperConfig,
+    masthead: dict[str, str],
+    *,
+    edition_date: str,
+    dry_run: bool,
+    result: dict,
+    replies: list[dict],
+) -> None:
+    inbox = config.inbox
+    # BODY.PEEK keeps the message unread — Seen is set only after success.
+    status, data = conn.fetch(msg_id, "(BODY.PEEK[])")
+    if status != "OK" or not data or not data[0]:
+        result["skipped"].append({"from": "", "reason": "could not fetch message"})
+        return
+    raw = data[0][1] if isinstance(data[0], (tuple, list)) else data[0]
+    msg = message_from_bytes(raw, policy=policy.default)
+    sender = parseaddr(str(msg.get("From", "")))[1].lower()
+    subject = str(msg.get("Subject", "") or "")
+    # THE gate: the masthead allowlist. No sender match, no staging — ever.
+    if sender not in masthead:
+        result["skipped"].append({"from": sender, "reason": "not on the masthead"})
+        return
+    if inbox.subject_tag and inbox.subject_tag.lower() not in subject.lower():
+        result["skipped"].append(
+            {"from": sender, "reason": f"subject tag '{inbox.subject_tag}' missing"}
+        )
+        return
+    contributor = masthead[sender]
+    text = _message_text(msg)
+    if not text.strip():
+        result["skipped"].append({"from": sender, "reason": "empty message"})
+        return
+    url = extract_first_url(text)
+    title = _clean_subject(subject, inbox.subject_tag)
+    if dry_run:
+        result["staged"].append(
+            {
+                "from": sender,
+                "contributor": contributor,
+                "kind": "url" if url else "note",
+                "source": url or sender,
+                "title": title or ("" if url else f"Note from {contributor}"),
+                "would_stage": True,
+            }
+        )
+        return
+    if url:
+        try:
+            item = stage_url(config, url, date_str=edition_date,
+                             title=title or None, contributor=contributor)
+        except ArticleExtractionError as exc:
+            result["skipped"].append({"from": sender, "reason": f"extraction failed: {exc}"})
+            return
+    else:
+        item = stage_markdown(
+            config,
+            text,
+            date_str=edition_date,
+            kind="note",
+            source=sender,
+            title=title or f"Note from {contributor}",
+            contributor=contributor,
+        )
+    conn.store(msg_id, "+FLAGS", "\\Seen")
+    result["staged"].append({"from": sender, **asdict(item)})
+    if inbox.reply:
+        replies.append({"to": sender, "subject": subject, "est_pages": item.est_pages})

--- a/src/morning_paper/renderers.py
+++ b/src/morning_paper/renderers.py
@@ -511,16 +511,21 @@ def _staged_section(config: MorningPaperConfig, date_str: str, *, template_style
         _meta, body = _split_frontmatter(staged_markdown)
         title = html.escape(str(item.get("title") or slug))
         source = html.escape(str(item.get("source") or ""))
+        # contributor-inbox items carry the masthead name — the kicker says who
+        # put this in the reader's paper
+        contributor = html.escape(str(item.get("contributor") or ""))
         notice = ""
         if item.get("truncated"):
             detail = html.escape(str(item.get("warning") or "the staged copy is incomplete"))
             notice = f'<div class="trunc-notice">Incomplete: {detail}</div>\n\n'
         if template_style == "typewriter":
-            head = f"### {title}\n\n" + (f'<p class="subhead">From {source}</p>\n\n' if source else "")
+            byline = f"From {contributor} — {source}" if contributor else (f"From {source}" if source else "")
+            head = f"### {title}\n\n" + (f'<p class="subhead">{byline}</p>\n\n' if byline else "")
         else:
+            kicker = f"From {contributor}" if contributor else f"Staged · {html.escape(str(item.get('kind') or 'item'))}"
             head = (
                 '<div class="article-head">'
-                f'<div class="dept-kicker">Staged · {html.escape(str(item.get("kind") or "item"))}</div>'
+                f'<div class="dept-kicker">{kicker}</div>'
                 f'<div class="dept-title">{title}</div>'
                 + (f'<div class="mg-byline">From <strong>{source}</strong></div>' if source else "")
                 + "</div>\n\n"

--- a/src/morning_paper/staging.py
+++ b/src/morning_paper/staging.py
@@ -18,6 +18,12 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from .article_print import (
+    article_truncation_report,
+    article_truncation_warning,
+    fetch_article,
+    render_article_markdown,
+)
 from .config import MorningPaperConfig
 from .renderers import _safe_filename, count_pages
 
@@ -26,7 +32,7 @@ from .renderers import _safe_filename, count_pages
 class StagedItem:
     slug: str
     kind: str            # url | file | note
-    source: str          # the URL or original path
+    source: str          # the URL, original path, or contributor address
     title: str
     words: int
     est_pages: int
@@ -35,6 +41,7 @@ class StagedItem:
     words_extracted: int | None = None  # words the extractor recovered before any render cap
     warning: str = ""                 # plain-language explanation when truncated
     extractor_note: str = ""          # honesty note: e.g. local extraction fell back to jina
+    contributor: str = ""             # masthead name when a trusted sender emailed this in
 
 
 def staging_dir(config: MorningPaperConfig, date_str: str) -> Path:
@@ -71,6 +78,7 @@ def stage_markdown(
     words_extracted: int | None = None,
     warning: str = "",
     extractor_note: str = "",
+    contributor: str = "",
 ) -> StagedItem:
     sdir = staging_dir(config, date_str)
     slug = _safe_filename(title)[:48] or "staged"
@@ -103,10 +111,51 @@ def stage_markdown(
         words_extracted=words_extracted,
         warning=warning,
         extractor_note=extractor_note,
+        contributor=contributor,
     )
     queue.append(asdict(item))
     _save_queue(sdir, queue)
     return item
+
+
+def stage_url(
+    config: MorningPaperConfig,
+    url: str,
+    *,
+    date_str: str,
+    title: str | None = None,
+    contributor: str = "",
+) -> StagedItem:
+    """Fetch a URL the way `print` does and stage it for the given edition.
+
+    The one staging path for URLs — the `stage` CLI command and the
+    contributor inbox both call this, so the honesty flags (truncation,
+    extractor fallback) are identical no matter how the URL arrived.
+    Raises ArticleExtractionError when the page cannot be extracted.
+    """
+    article = fetch_article(url, extractor_name=config.article_extractor)
+    markdown = render_article_markdown(
+        config,
+        [article],
+        date_str=date_str,
+        images_dir=config.outputs.directory / "staging" / date_str / "_images",
+    )
+    # Honesty rule: if extraction or the render cap clipped the article,
+    # say so plainly in the staged record instead of staging silently.
+    report = article_truncation_report(article)
+    return stage_markdown(
+        config,
+        markdown,
+        date_str=date_str,
+        kind="url",
+        source=url,
+        title=title or article.title,
+        truncated=bool(report["truncated"]),
+        words_extracted=int(report["words_extracted"]),
+        warning=article_truncation_warning(article),
+        extractor_note=article.extraction_note,
+        contributor=contributor,
+    )
 
 
 def queue_status(config: MorningPaperConfig, date_str: str) -> dict:

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -173,7 +173,7 @@ class LocalExtractorTest(unittest.TestCase):
             config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
             stdout = io.StringIO()
-            with patch("morning_paper.cli.fetch_article", return_value=article):
+            with patch("morning_paper.staging.fetch_article", return_value=article):
                 with redirect_stdout(stdout):
                     rc = cli.main(
                         ["stage", article.url, "--config", str(config_path), "--date", "2026-06-12"]

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from email.message import EmailMessage
+from pathlib import Path
+from unittest.mock import patch
+
+from morning_paper import cli
+from morning_paper.article_print import Article, ArticleExtractionError
+from morning_paper.config import ContributorConfig, InboxConfig, MorningPaperConfig
+from morning_paper.inbox import derive_smtp_host, extract_first_url, poll_inbox
+
+
+READER = "reader@example.com"
+SAM = "sam@example.com"
+
+
+def _mail(sender: str, subject: str, body: str, *, html: bool = False) -> bytes:
+    msg = EmailMessage()
+    msg["From"] = f"Somebody <{sender}>"
+    msg["To"] = READER
+    msg["Subject"] = subject
+    if html:
+        msg.set_content(body, subtype="html")
+    else:
+        msg.set_content(body)
+    return msg.as_bytes()
+
+
+class FakeIMAP:
+    """Stands in for imaplib.IMAP4_SSL; one mailbox dict shared per test."""
+
+    instances: list["FakeIMAP"] = []
+    mailbox_data: dict[bytes, bytes] = {}
+
+    def __init__(self, host: str) -> None:
+        self.host = host
+        self.logged_in: tuple[str, str] | None = None
+        self.selected: str | None = None
+        self.seen: list[bytes] = []
+        FakeIMAP.instances.append(self)
+
+    def login(self, user: str, password: str):
+        self.logged_in = (user, password)
+        return ("OK", [b"Logged in"])
+
+    def select(self, mailbox: str):
+        self.selected = mailbox
+        return ("OK", [b"1"])
+
+    def search(self, charset, *criteria):
+        ids = b" ".join(sorted(FakeIMAP.mailbox_data.keys()))
+        return ("OK", [ids])
+
+    def fetch(self, msg_id: bytes, spec: str):
+        assert "PEEK" in spec, "fetch must use BODY.PEEK so reading never marks Seen"
+        return ("OK", [(msg_id + b" (BODY[] {...})", FakeIMAP.mailbox_data[msg_id])])
+
+    def store(self, msg_id: bytes, flags: str, value: str):
+        self.seen.append(msg_id)
+        return ("OK", [])
+
+    def logout(self):
+        return ("BYE", [])
+
+    @classmethod
+    def reset(cls, mailbox: dict[bytes, bytes]) -> None:
+        cls.instances = []
+        cls.mailbox_data = dict(mailbox)
+
+
+class FakeSMTP:
+    instances: list["FakeSMTP"] = []
+
+    def __init__(self, host: str) -> None:
+        self.host = host
+        self.logged_in: tuple[str, str] | None = None
+        self.sent: list[EmailMessage] = []
+        FakeSMTP.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def login(self, user: str, password: str):
+        self.logged_in = (user, password)
+
+    def send_message(self, message: EmailMessage):
+        self.sent.append(message)
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.instances = []
+
+
+def _article() -> Article:
+    sentence = "A complete sentence with enough words to look like real prose."
+    return Article(
+        url="https://example.com/story",
+        title="A Staged Story",
+        author="Author",
+        source_name="Example",
+        body="",
+        blocks=[("paragraph", sentence) for _ in range(5)],
+    )
+
+
+class InboxTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        self.config = MorningPaperConfig()
+        self.config.outputs.directory = self.tmp / "out"
+        self.config.outputs.directory.mkdir(parents=True)
+        self.config.inbox = InboxConfig(
+            enabled=True,
+            imap_host="imap.example.com",
+            imap_user=READER,
+            subject_tag="paper",
+            contributors=[ContributorConfig(email=SAM, name="Sam")],
+            reply=True,
+        )
+        env = patch.dict("os.environ", {"MORNING_PAPER_IMAP_PASSWORD": "app-password"})
+        env.start()
+        self.addCleanup(env.stop)
+        FakeSMTP.reset()
+
+    def _poll(self, mailbox: dict[bytes, bytes], **kwargs) -> dict:
+        FakeIMAP.reset(mailbox)
+        with patch("imaplib.IMAP4_SSL", FakeIMAP), patch("smtplib.SMTP_SSL", FakeSMTP):
+            return poll_inbox(self.config, date_str="2026-06-12", **kwargs)
+
+    def _queue(self) -> list[dict]:
+        queue_file = self.tmp / "out" / "staging" / "2026-06-12" / "queue.json"
+        if not queue_file.exists():
+            return []
+        return json.loads(queue_file.read_text(encoding="utf-8"))
+
+
+class MastheadGateTest(InboxTestCase):
+    def test_non_masthead_sender_is_skipped_and_left_unread(self) -> None:
+        result = self._poll(
+            {
+                b"1": _mail("stranger@example.com", "paper: read this", "https://example.com/story"),
+                b"2": _mail(SAM, "paper: a note", "Just a note for tomorrow."),
+            }
+        )
+        self.assertEqual(result["polled"], 2)
+        self.assertEqual([s["from"] for s in result["skipped"]], ["stranger@example.com"])
+        self.assertIn("masthead", result["skipped"][0]["reason"])
+        self.assertEqual(len(result["staged"]), 1)
+        self.assertEqual(result["staged"][0]["from"], SAM)
+        # only Sam's message is marked Seen; the stranger's stays unread
+        self.assertEqual(FakeIMAP.instances[0].seen, [b"2"])
+        # the stranger's URL never reached the queue
+        self.assertEqual(len(self._queue()), 1)
+        self.assertEqual(self._queue()[0]["contributor"], "Sam")
+
+    def test_subject_tag_filter(self) -> None:
+        result = self._poll({b"1": _mail(SAM, "lunch on sunday?", "no link here")})
+        self.assertEqual(result["staged"], [])
+        self.assertIn("subject tag", result["skipped"][0]["reason"])
+        self.assertEqual(FakeIMAP.instances[0].seen, [])
+
+
+class StagingTest(InboxTestCase):
+    def test_url_mail_stages_via_fetch_article(self) -> None:
+        with patch("morning_paper.staging.fetch_article", return_value=_article()) as fetched:
+            result = self._poll(
+                {b"1": _mail(SAM, "[paper] worth your time", "you should read this https://example.com/story ok")}
+            )
+        fetched.assert_called_once()
+        self.assertEqual(fetched.call_args[0][0], "https://example.com/story")
+        staged = result["staged"][0]
+        self.assertEqual(staged["kind"], "url")
+        self.assertEqual(staged["source"], "https://example.com/story")
+        self.assertEqual(staged["contributor"], "Sam")
+        self.assertEqual(staged["title"], "worth your time")
+        self.assertEqual(self._queue()[0]["contributor"], "Sam")
+
+    def test_note_only_mail_stages_as_note(self) -> None:
+        result = self._poll({b"1": _mail(SAM, "paper: from the garden", "The tomatoes finally came in.")})
+        staged = result["staged"][0]
+        self.assertEqual(staged["kind"], "note")
+        self.assertEqual(staged["source"], SAM)
+        self.assertEqual(staged["title"], "from the garden")
+        queue = self._queue()
+        self.assertEqual(queue[0]["kind"], "note")
+        staged_md = (self.tmp / "out" / "staging" / "2026-06-12" / f"{queue[0]['slug']}.md").read_text(encoding="utf-8")
+        self.assertIn("tomatoes", staged_md)
+
+    def test_html_only_mail_is_treated_as_untrusted_text(self) -> None:
+        body = (
+            "<p>read <a href=\"https://example.com/story\">this</a></p>"
+            "<script>steal('credentials')</script>"
+        )
+        with patch("morning_paper.staging.fetch_article", return_value=_article()):
+            result = self._poll({b"1": _mail(SAM, "paper", body, html=True)})
+        staged = result["staged"][0]
+        self.assertEqual(staged["kind"], "url")
+        self.assertEqual(staged["source"], "https://example.com/story")
+        # nothing from the script block survives anywhere
+        self.assertNotIn("steal", json.dumps(result))
+
+    def test_failed_extraction_skips_and_never_marks_seen(self) -> None:
+        with patch(
+            "morning_paper.staging.fetch_article",
+            side_effect=ArticleExtractionError("could not extract"),
+        ):
+            result = self._poll({b"1": _mail(SAM, "paper: read", "https://example.com/broken")})
+        self.assertEqual(result["staged"], [])
+        self.assertIn("extraction failed", result["skipped"][0]["reason"])
+        self.assertEqual(FakeIMAP.instances[0].seen, [])
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(FakeSMTP.instances, [])
+
+
+class DryRunTest(InboxTestCase):
+    def test_dry_run_stages_nothing_and_touches_nothing(self) -> None:
+        result = self._poll(
+            {b"1": _mail(SAM, "paper: a note", "Just a note.")},
+            dry_run=True,
+        )
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(len(result["staged"]), 1)
+        self.assertTrue(result["staged"][0]["would_stage"])
+        self.assertEqual(result["replied"], 0)
+        self.assertEqual(self._queue(), [])
+        self.assertEqual(FakeIMAP.instances[0].seen, [])
+        self.assertEqual(FakeSMTP.instances, [])
+
+
+class ReplyTest(InboxTestCase):
+    def test_reply_is_warm_from_the_reader_with_page_estimate(self) -> None:
+        result = self._poll({b"1": _mail(SAM, "paper: from the garden", "The tomatoes finally came in.")})
+        self.assertEqual(result["replied"], 1)
+        smtp = FakeSMTP.instances[0]
+        # smtp host derived from the imap host; sender is the reader's own address
+        self.assertEqual(smtp.host, "smtp.example.com")
+        self.assertEqual(smtp.logged_in, (READER, "app-password"))
+        message = smtp.sent[0]
+        self.assertEqual(message["From"], READER)
+        self.assertEqual(message["To"], SAM)
+        self.assertEqual(message["Subject"], "Re: paper: from the garden")
+        body = message.get_content()
+        self.assertIn("Got it", body)
+        self.assertIn("Morning Paper tomorrow morning", body)
+        self.assertIn("about 1 page", body)
+        self.assertIn("☕", body)
+
+    def test_reply_disabled_sends_nothing(self) -> None:
+        self.config.inbox.reply = False
+        result = self._poll({b"1": _mail(SAM, "paper: note", "A note.")})
+        self.assertEqual(result["replied"], 0)
+        self.assertEqual(FakeSMTP.instances, [])
+        self.assertEqual(len(result["staged"]), 1)
+
+
+class HelpersTest(unittest.TestCase):
+    def test_derive_smtp_host(self) -> None:
+        self.assertEqual(derive_smtp_host("imap.gmail.com"), "smtp.gmail.com")
+        self.assertEqual(derive_smtp_host("imap.mail.me.com"), "smtp.mail.me.com")
+        self.assertEqual(derive_smtp_host("mail.example.org"), "mail.example.org")
+
+    def test_extract_first_url(self) -> None:
+        self.assertEqual(
+            extract_first_url("look: https://example.com/a?x=1 and https://example.com/b"),
+            "https://example.com/a?x=1",
+        )
+        self.assertEqual(extract_first_url("no links"), "")
+
+
+class CliInboxTest(unittest.TestCase):
+    def _write_config(self, tmp: Path, *, inbox_block: str) -> Path:
+        config_path = tmp / "config.yaml"
+        config_path.write_text(
+            f"""name: Morning Paper
+timezone: America/Los_Angeles
+outputs:
+  directory: {tmp / 'out'}
+{inbox_block}
+""",
+            encoding="utf-8",
+        )
+        return config_path
+
+    def test_inbox_json_shape(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            config_path = self._write_config(
+                tmp,
+                inbox_block=f"""inbox:
+  enabled: true
+  imap_host: imap.example.com
+  imap_user: {READER}
+  contributors:
+    - email: {SAM}
+      name: Sam
+""",
+            )
+            FakeIMAP.reset({b"1": _mail(SAM, "paper: note", "A note for tomorrow.")})
+            FakeSMTP.reset()
+            stdout = io.StringIO()
+            with patch.dict("os.environ", {"MORNING_PAPER_IMAP_PASSWORD": "app-password"}):
+                with patch("imaplib.IMAP4_SSL", FakeIMAP), patch("smtplib.SMTP_SSL", FakeSMTP):
+                    with redirect_stdout(stdout):
+                        rc = cli.main(["inbox", "poll", "--config", str(config_path)])
+            self.assertEqual(rc, 0)
+            payload = json.loads(stdout.getvalue())
+            for key in ("polled", "staged", "replied", "skipped", "edition_date", "dry_run"):
+                self.assertIn(key, payload)
+            self.assertEqual(payload["polled"], 1)
+            self.assertEqual(len(payload["staged"]), 1)
+            self.assertEqual(payload["replied"], 1)
+            self.assertEqual(payload["skipped"], [])
+
+    def test_inbox_disabled_config_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            config_path = self._write_config(tmp, inbox_block="")
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                rc = cli.main(["inbox", "--config", str(config_path)])
+            self.assertEqual(rc, 1)
+            message = stderr.getvalue()
+            self.assertIn("not configured", message)
+            self.assertIn("inbox.enabled", message)
+            self.assertIn("docs/inbox.md", message)
+
+    def test_enabled_inbox_requires_masthead(self) -> None:
+        from morning_paper.config import ConfigError, load_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            config_path = self._write_config(
+                tmp,
+                inbox_block=f"""inbox:
+  enabled: true
+  imap_host: imap.example.com
+  imap_user: {READER}
+""",
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(config_path)
+            self.assertIn("contributors", str(ctx.exception))
+
+    def test_password_in_config_is_rejected(self) -> None:
+        from morning_paper.config import ConfigError, load_config
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = Path(tmp_dir)
+            config_path = self._write_config(
+                tmp,
+                inbox_block=f"""inbox:
+  enabled: true
+  imap_host: imap.example.com
+  imap_user: {READER}
+  imap_password: hunter2
+  contributors:
+    - email: {SAM}
+      name: Sam
+""",
+            )
+            with self.assertRaises(ConfigError) as ctx:
+                load_config(config_path)
+            self.assertIn("MORNING_PAPER_IMAP_PASSWORD", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -108,7 +108,7 @@ class StageTruncationTest(unittest.TestCase):
             config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
             stdout = io.StringIO()
-            with patch("morning_paper.cli.fetch_article", return_value=article):
+            with patch("morning_paper.staging.fetch_article", return_value=article):
                 with redirect_stdout(stdout):
                     rc = cli.main(
                         [


### PR DESCRIPTION
## What

People the reader trusts email articles in; they land in tomorrow's staging queue; the sender gets a warm confirmation back. `morning-paper inbox` (alias `inbox poll`) polls a mailbox over IMAP — stdlib only (`imaplib`/`smtplib`/`email`), no new dependencies, no webhook, no service.

The contributor list is called what it is: **the masthead**. Staged contributor items print with a FROM <NAME> kicker — the paper says who sent it in.

## How

- **Config** — new top-level `inbox:` block (`enabled: false` by default): `imap_host`/`imap_user`, `mailbox`, optional `subject_tag` filter (default `paper`), `reply`, optional `smtp_host`/`smtp_user` (derived from the IMAP values when omitted), and `contributors:` — a strict `{email, name}` allowlist, required non-empty when enabled.
- **Security** — the masthead is THE gate: mail from any other sender is skipped and reported, never staged. All mail content is untrusted text (HTML payloads lose script/style blocks and every tag before anything is read). Passwords never go in config: `MORNING_PAPER_IMAP_PASSWORD` (+ `MORNING_PAPER_SMTP_PASSWORD` when distinct), and the loader rejects any `password` key in the block with the fix in the error.
- **Staging** — the first `http(s)` URL stages through the same path as `stage <url>` (new shared `staging.stage_url` helper; `stage_command` now uses it too — one URL path, same honesty flags). No URL means the body stages as kind `note`. `StagedItem` gains `contributor`.
- **Safety** — messages fetched with `BODY.PEEK`, marked Seen ONLY after a successful stage; one bad message never crashes the poll (it lands in `skipped` with a reason); `--dry-run` reports what WOULD stage without staging, replying, or marking anything read.
- **The reply** — warm, short, from the reader's own address, with the real page estimate: *"Got it — this is in Morning Paper tomorrow morning (about 4 pages). ☕"*
- **Docs & skills** — new [docs/inbox.md](docs/inbox.md) (Gmail/iCloud app-password walkthrough, plus-addressing tip, the one-sentence contributor onboarding); README For Agents verb; `setup` skill interviews for the masthead (with the future Worker door honestly labeled not-yet-shipped); `edition` skill polls the inbox before composing.

## Version

0.4.4 (additive, no breaking changes) — pyproject, `__init__`, plugin.json, CHANGELOG.

## Tests

76 passed (61 baseline + 15 new): fake-IMAP/SMTP coverage for the masthead gate, URL extraction, note staging, HTML stripping, seen-marking only on success, dry-run, reply content, CLI JSON shape, disabled-config error, and the config guards (masthead required, password-in-config rejected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)