### PR TITLE
morning-paper routine: the paper without the chat (0.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-paper",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Your personal newsroom: a daily printed paper composed by your agent from your sources, with preferences you own as files.",
   "author": { "name": "Devon Meadows", "url": "https://github.com/dmthepm" },
   "homepage": "https://github.com/dmthepm/morning-paper",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-12
+
+### Added
+- **`morning-paper routine` — the paper without the chat.** The editor is an agent, so the scheduled job is just `claude -p` run headless against the user's existing subscription: `routine install` schedules a daily run of the edition skill (default 05:00, `--time HH:MM` to change, `--command CMD` to replace the job; if `claude` is not on PATH the install refuses, warns, and prints the exact command to wire into your own scheduler). Platform ladder: macOS gets a launchd LaunchAgent (`~/Library/LaunchAgents/com.morning-paper.edition.plist`) using `StartCalendarInterval` — chosen because launchd coalesces runs missed during sleep into one run on wake, so the paper is ready when the laptop opens; `RunAtLoad` stays false (install never triggers an immediate run) and the installing user's `PATH` is frozen into the job so launchd's minimal environment can still find `claude`. Linux gets a systemd user timer with `Persistent=true` (the same catch-up behavior), falling back to a crontab line with the honest note that cron has no coalescing. Loading prefers `launchctl bootstrap gui/$UID` with a legacy `launchctl load` fallback
+- `routine status` — JSON: installed?, scheduler, schedule (time + plain-language semantics), the raw command, last run (parsed from timestamped run markers the routine wraps around every invocation in `~/.local/share/morning-paper/routine.log`, plus `launchctl print` state on macOS), computed next fire, and the log path. `routine uninstall` removes the job cleanly and is idempotent — uninstalling an absent routine is a no-op, not an error
+- `doctor` now reports the routine (installed/not, scheduler, time) — in `--json` under `"routine"` and as a human line; absence is informational, never an error
+- The scheduling ladder documented in the README ("The morning routine"): Tier 0 say-"paper"-each-morning, Tier 1 `routine install` laptop-wake magic, Tier 2 always-on (+ the `pmset repeat wakeorpoweron` note for self-waking Macs), Tier 3 cloud-compose split. docs/composing.md points at the seam; the setup skill's routine section now offers the real command and the ladder
+- 27 new tests: plist/systemd/cron unit generation (content, quoting, `%`-escaping per scheduler), install flows with subprocess mocked (no real launchctl/systemctl/crontab in CI), the bootstrap→load fallback, run-marker log parsing, status JSON, uninstall idempotence, the no-claude-binary warning path, and doctor's routine report
+
 ## [0.5.0] - 2026-06-11
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ newsroom repo, first edition, daily loop). Otherwise:
    - `morning-paper queue` -> what's staged vs the page budget
    - `morning-paper estimate <file.md>` -> page count, nothing written
    - `morning-paper render <file.md> --style <s> --palette <p>` -> the PDF
-   - `morning-paper doctor --json` -> machine-readable install status
+   - `morning-paper routine install|status|uninstall` -> schedule the daily
+     edition as a headless `claude -p` run (the scheduling ladder, below);
+     `status` answers "did the paper build this morning?" in JSON
+   - `morning-paper doctor --json` -> machine-readable install status,
+     including whether the routine is installed
      (add `--strict` to get a nonzero exit when the typewriter renderer
      is unavailable)
 4. Page estimates need the pretty print stack (`[pretty]` + WeasyPrint):
@@ -149,6 +153,41 @@ Artifacts land under:
 
 The plain `morning-paper` install (no `[pretty]`) falls back to a simpler
 renderer — it works, but it is not the output you should judge the product by.
+
+## The morning routine (the scheduling ladder)
+
+The paper is best when it is simply *there*. Four tiers, in order of effort —
+climb only as far as you want.
+
+**Tier 0 — say "paper" each morning.** The default. Open Claude Code and ask
+for your paper (the `edition` skill). Zero setup, full control, and you watch
+the editor work. Most readers should start — and many should stay — here.
+
+**Tier 1 — `morning-paper routine install`.** One command schedules a daily
+headless run: `claude -p` invokes the edition skill through your existing
+Claude subscription — no extra API key, no daemon. Default time is 05:00
+(`--time HH:MM` to change it, `--command CMD` to replace the job entirely).
+On macOS this is a launchd LaunchAgent using `StartCalendarInterval`, chosen
+deliberately because launchd *coalesces* runs missed during sleep into one
+run on the next wake: a closed laptop at 5am means the paper builds the
+moment you open it, instead of being skipped. On Linux it is a systemd user
+timer with `Persistent=true` (same catch-up behavior), falling back to a
+crontab line where systemd is absent — with the honest note that cron has no
+coalescing. `morning-paper routine status` reports schedule, last run, and
+next fire as JSON; `routine uninstall` removes it cleanly; the job logs to
+`~/.local/share/morning-paper/routine.log`.
+
+**Tier 2 — always-on.** A Mac mini, desktop, or home server that never
+sleeps runs the same routine at exactly 05:00 every day — pair it with a
+printer and the paper is on the tray before you wake. A Mac that should wake
+itself instead of staying on: `sudo pmset repeat wakeorpoweron MTWRFSU
+04:55:00` wakes it five minutes before the routine fires.
+
+**Tier 3 — the cloud-compose split.** Compose in the cloud, print at home: a
+scheduled cloud agent (or CI job) runs the edition skill on its own clock and
+commits the composed markdown to your newsroom repo; any local machine that
+comes online runs `morning-paper render` and the print command. The judgment
+can run anywhere — the paper still lands on your desk.
 
 ## Sources
 

--- a/docs/composing.md
+++ b/docs/composing.md
@@ -297,3 +297,13 @@ local` or `article_extractor: jina` in config.
 Both paths feed the same validation gate (shell pages and too-short
 extractions are rejected, never printed) and the same truncation reporting
 (`truncated`, `words_extracted`, plain-language `warning`).
+
+## Scheduling the daily compose
+
+The composition pass itself can run unattended: `morning-paper routine
+install` schedules a daily headless `claude -p` run of the edition skill
+(launchd on macOS with missed-run coalescing, systemd user timer with
+`Persistent=true` on Linux, cron fallback). `morning-paper routine status`
+reports schedule, last run, and next fire as JSON — the seam for "did my
+paper build this morning?". The full scheduling ladder (Tier 0 manual through
+Tier 3 cloud-compose) is in the README's "The morning routine" section.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.5.0"
+version = "0.5.1"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -87,11 +87,34 @@ collectors/   # any custom source scripts
 Explain the point in one line: *your feed has an algorithm you can't see;
 your paper's algorithm is files you can read and edit.*
 
-## 6. The morning routine
+## 6. The morning routine (offer the ladder)
 
-Offer to schedule it (Claude scheduled tasks / cron): every morning run the
-`edition` skill of this plugin. If they prefer manual, the command is just
-invoking `/morning-paper:edition`.
+Tier 0 is the default and needs nothing: each morning they say "paper" (or
+invoke `/morning-paper:edition`) and watch the editor work. Offer the next
+rung — one command:
+
+```bash
+morning-paper routine install                  # daily at 05:00
+morning-paper routine install --time 06:30     # their wake time beats the default
+morning-paper routine status                   # schedule, last run, next fire (JSON)
+```
+
+This schedules a headless `claude -p` run of the edition skill through their
+existing subscription (`--permission-mode acceptEdits`) — no extra API key.
+On macOS it is a launchd agent that coalesces runs missed during sleep into
+one run on wake: the paper builds the moment the laptop opens. On Linux it is
+a systemd user timer with `Persistent=true`, falling back to cron (say
+plainly: cron skips runs missed while asleep). The job logs to
+`~/.local/share/morning-paper/routine.log`; `--command CMD` swaps in their
+own job. If `claude` is not on PATH the install refuses, warns, and prints
+the exact command to wire into their own scheduler — relay that honestly.
+
+Mention the higher rungs only if they want more: an always-on machine runs
+the routine at exactly the set time (a Mac that should wake itself instead:
+`sudo pmset repeat wakeorpoweron MTWRFSU 04:55:00`); the cloud-compose split
+(a scheduled cloud agent composes into the newsroom repo, any local machine
+renders and prints) is the top of the ladder — see the README's "The morning
+routine" section.
 
 ## 7. First edition, now
 

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/morning_paper/cli.py
+++ b/src/morning_paper/cli.py
@@ -46,6 +46,8 @@ Commands:
   queue             Show what's staged vs the page budget (JSON)
   estimate <file>   Page count for a markdown file, nothing written
   styles            List available styles and palettes
+  routine           Schedule the daily edition (install [--time HH:MM]
+                    [--command CMD] | status | uninstall) — launchd/systemd/cron
   doctor            Check config, dependencies, and renderer status (--json, --strict)
   --version         Show installed version
 
@@ -108,6 +110,16 @@ def _renderer_hint_lines(renderer_error: str | None) -> list[str]:
     return _pretty_install_hint_lines()
 
 
+def _routine_status_line(routine_info: dict) -> str:
+    # Absence is not a problem — the routine is an optional convenience tier.
+    if routine_info.get("installed"):
+        time_str = routine_info.get("time")
+        scheduler = routine_info.get("scheduler")
+        detail = f"daily at {time_str} via {scheduler}" if time_str else f"via {scheduler}"
+        return f"routine: installed ({detail})"
+    return "routine: not installed (optional — `morning-paper routine install` schedules the morning edition)"
+
+
 def doctor(args: list[str] | None = None) -> int:
     usage = "usage: morning-paper doctor [--json] [--strict]"
     as_json = False
@@ -134,6 +146,7 @@ def doctor(args: list[str] | None = None) -> int:
         "morning_paper.image_tools",
         "morning_paper.inbox",
         "morning_paper.renderers",
+        "morning_paper.routine",
         "morning_paper.sources",
     ]
     for module_name in required_modules:
@@ -153,6 +166,10 @@ def doctor(args: list[str] | None = None) -> int:
     _, renderer_error = _load_weasyprint()
     typewriter_ready = renderer_error is None
     hints = [] if typewriter_ready else _renderer_hint_lines(renderer_error)
+    # The routine is optional: report installed/not, never an error when absent.
+    from .routine import routine_doctor_summary
+
+    routine_info = routine_doctor_summary()
     if missing:
         status = "broken"
     elif typewriter_ready:
@@ -170,6 +187,7 @@ def doctor(args: list[str] | None = None) -> int:
                 "error": renderer_error,
                 "hints": hints,
             },
+            "routine": routine_info,
             "status": status,
         }
         print(json.dumps(payload, indent=2))
@@ -182,6 +200,7 @@ def doctor(args: list[str] | None = None) -> int:
     if not typewriter_ready:
         print("doctor: ok")
         print("renderer: typewriter unavailable")
+        print(_routine_status_line(routine_info))
         print("status: fallback-only install; high-quality print output is not available yet")
         for line in hints:
             print(line)
@@ -189,6 +208,7 @@ def doctor(args: list[str] | None = None) -> int:
         return exit_code
     print("doctor: ok")
     print("renderer: typewriter ready")
+    print(_routine_status_line(routine_info))
     print("status: high-quality print path available")
     _print_update_notice()
     return exit_code
@@ -803,6 +823,10 @@ def main(argv: list[str] | None = None) -> int:
         return estimate_command(extra)
     if command == "styles":
         return styles_command()
+    if command == "routine":
+        from .routine import routine_command
+
+        return routine_command(extra)
     if command == "doctor":
         return doctor(extra)
     if command in ROADMAP_COMMANDS:

--- a/src/morning_paper/routine.py
+++ b/src/morning_paper/routine.py
@@ -1,0 +1,645 @@
+"""The morning routine: schedule the daily edition without opening a chat.
+
+The editor is an agent, so the scheduled job is just `claude -p` run headless
+against the user's existing subscription — no extra API key, no daemon of ours.
+This module owns the scheduling ladder's Tier 1/2 rung: a per-user job on the
+platform's native scheduler.
+
+Platform mapping:
+
+- darwin  -> launchd (a LaunchAgent plist with ``StartCalendarInterval``).
+  Chosen deliberately over cron: launchd *coalesces missed runs* — if the Mac
+  was asleep at the scheduled minute, the job fires once on the next wake
+  instead of being skipped. That is the product promise ("the paper is ready
+  when you open the laptop") without fighting anyone's sleep schedule.
+- linux   -> systemd user timer with ``Persistent=true`` (the systemd
+  equivalent of coalescing: a missed run is made up at the next opportunity).
+  Falls back to a crontab line when systemd is unavailable — with the honest
+  note that cron has no coalescing: a run missed during sleep is simply gone.
+
+Everything prints JSON; ``routine status`` parses the run-marker lines this
+module wraps around the command, so "did my paper actually build this
+morning?" has a machine-readable answer.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+LAUNCHD_LABEL = "com.morning-paper.edition"
+SYSTEMD_UNIT = "morning-paper-edition"
+CRON_MARKER = "# morning-paper routine"
+DEFAULT_TIME = "05:00"
+
+# The default job: run the edition skill headless through the user's own
+# Claude subscription. Documented as overridable via `--command` — any shell
+# command works; this is just the one that turns the plugin into a newspaper
+# delivery service.
+DEFAULT_COMMAND = (
+    'claude -p "Run the morning-paper edition skill: compose, render, and '
+    "deliver today's edition per my newsroom configuration.\" "
+    "--permission-mode acceptEdits"
+)
+
+# Run markers written around every scheduled invocation so `routine status`
+# can report the last run honestly from the log alone.
+RUN_START_PREFIX = "[morning-paper routine] start "
+RUN_EXIT_PREFIX = "[morning-paper routine] exit "
+
+
+# --- small seams, kept patchable for tests (no real launchctl/systemctl/crontab in CI) ---
+
+
+def _current_platform() -> str:
+    return sys.platform
+
+
+def _resolve_claude() -> str | None:
+    return shutil.which("claude")
+
+
+def _tool_exists(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def _run(args: list[str], input_text: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        args, input=input_text, capture_output=True, text=True, timeout=30, check=False
+    )
+
+
+# --- paths ---
+
+
+def log_path() -> Path:
+    # Stated path, independent of config: the log must be findable even when
+    # config.yaml is missing or broken (that is exactly when you read a log).
+    return Path.home() / ".local" / "share" / "morning-paper" / "routine.log"
+
+
+def launchd_plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LAUNCHD_LABEL}.plist"
+
+
+def systemd_unit_dir() -> Path:
+    return Path.home() / ".config" / "systemd" / "user"
+
+
+def systemd_service_path() -> Path:
+    return systemd_unit_dir() / f"{SYSTEMD_UNIT}.service"
+
+
+def systemd_timer_path() -> Path:
+    return systemd_unit_dir() / f"{SYSTEMD_UNIT}.timer"
+
+
+# --- schedule + command plumbing ---
+
+
+def parse_time(value: str) -> tuple[int, int]:
+    match = re.fullmatch(r"(\d{1,2}):(\d{2})", value.strip())
+    if not match:
+        raise ValueError(f"invalid --time {value!r}: expected HH:MM (24h), e.g. 05:00")
+    hour, minute = int(match.group(1)), int(match.group(2))
+    if hour > 23 or minute > 59:
+        raise ValueError(f"invalid --time {value!r}: hour 00-23, minute 00-59")
+    return hour, minute
+
+
+def _wrap_command(command: str) -> str:
+    """Bracket the job with timestamped run markers for `routine status`."""
+    return (
+        f"echo \"{RUN_START_PREFIX}$(date '+%Y-%m-%dT%H:%M:%S%z')\"; "
+        f"{command}; rc=$?; "
+        f'echo "{RUN_EXIT_PREFIX}$rc"; exit $rc'
+    )
+
+
+def _unwrap_command(wrapped: str) -> str | None:
+    """Recover the raw command from a wrapper this module generated."""
+    match = re.search(r"\)\"; (.*); rc=\$\?; ", wrapped, flags=re.DOTALL)
+    return match.group(1) if match else None
+
+
+def detect_scheduler(platform: str | None = None) -> str:
+    platform = platform or _current_platform()
+    if platform == "darwin":
+        return "launchd"
+    if platform.startswith("linux"):
+        if _tool_exists("systemctl"):
+            return "systemd"
+        if _tool_exists("crontab"):
+            return "cron"
+        return "none"
+    return "none"
+
+
+def schedule_semantics(scheduler: str, time_str: str) -> str:
+    if scheduler == "launchd":
+        return (
+            f"daily at {time_str} local time; runs missed while asleep are "
+            "coalesced into one run on wake"
+        )
+    if scheduler == "systemd":
+        return (
+            f"daily at {time_str} local time; Persistent=true replays a "
+            "missed run at the next opportunity"
+        )
+    if scheduler == "cron":
+        return (
+            f"daily at {time_str} local time; NOTE: cron has no coalescing — "
+            "a run missed while the machine sleeps is skipped"
+        )
+    return f"daily at {time_str} local time"
+
+
+def next_fire(time_str: str, now: datetime | None = None) -> str:
+    """Next wall-clock fire time. With coalescing, 'or first wake after'."""
+    hour, minute = parse_time(time_str)
+    now = now or datetime.now().astimezone()
+    candidate = now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= now:
+        candidate += timedelta(days=1)
+    return candidate.isoformat(timespec="minutes")
+
+
+# --- unit generation (pure, fully testable) ---
+
+
+def build_launchd_plist(time_str: str = DEFAULT_TIME, command: str = DEFAULT_COMMAND) -> dict:
+    hour, minute = parse_time(time_str)
+    return {
+        "Label": LAUNCHD_LABEL,
+        # /bin/sh -c keeps the command a plain shell string the user can read
+        # back out of the plist; launchd itself does no shell parsing.
+        "ProgramArguments": ["/bin/sh", "-c", _wrap_command(command)],
+        # launchd gives agents a minimal PATH (/usr/bin:/bin:...) that omits
+        # the homebrew / uv-tool directories where `claude` actually lives,
+        # so freeze the installing user's PATH into the job.
+        "EnvironmentVariables": {
+            "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        },
+        # WHY StartCalendarInterval (and not cron or an interval timer):
+        # launchd coalesces StartCalendarInterval runs missed during sleep —
+        # if the Mac was closed at the scheduled minute, the job fires once on
+        # the next wake instead of being skipped. The paper is ready when the
+        # laptop opens, whatever time that turns out to be.
+        "StartCalendarInterval": {"Hour": hour, "Minute": minute},
+        # Install must not trigger an immediate run; the first edition fires
+        # at the next scheduled time.
+        "RunAtLoad": False,
+        "StandardOutPath": str(log_path()),
+        "StandardErrorPath": str(log_path()),
+    }
+
+
+def _systemd_escape(command: str) -> str:
+    # systemd expands % specifiers inside ExecStart and uses backslash escapes
+    # in double-quoted words.
+    return command.replace("\\", "\\\\").replace("%", "%%").replace('"', '\\"')
+
+
+def build_systemd_service(command: str = DEFAULT_COMMAND) -> str:
+    wrapped = _systemd_escape(_wrap_command(command))
+    return (
+        "[Unit]\n"
+        "Description=Morning Paper daily edition\n"
+        "\n"
+        "[Service]\n"
+        "Type=oneshot\n"
+        f'ExecStart=/bin/sh -c "{wrapped}"\n'
+        f"StandardOutput=append:{log_path()}\n"
+        f"StandardError=append:{log_path()}\n"
+    )
+
+
+def build_systemd_timer(time_str: str = DEFAULT_TIME) -> str:
+    hour, minute = parse_time(time_str)
+    return (
+        "[Unit]\n"
+        "Description=Morning Paper daily edition timer\n"
+        "\n"
+        "[Timer]\n"
+        f"OnCalendar=*-*-* {hour:02d}:{minute:02d}:00\n"
+        "# Persistent=true is the coalescing behavior: a run missed while the\n"
+        "# machine was off or asleep is made up at the next opportunity.\n"
+        "Persistent=true\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=timers.target\n"
+    )
+
+
+def build_cron_line(time_str: str = DEFAULT_TIME, command: str = DEFAULT_COMMAND) -> str:
+    hour, minute = parse_time(time_str)
+    # The wrapped command rides inside single quotes, so embedded single
+    # quotes (the date format, "today's") become '\'' — and cron turns an
+    # unescaped % into a newline inside the command field, hence \%.
+    wrapped = _wrap_command(command).replace("'", "'\\''").replace("%", r"\%")
+    return (
+        f"{minute} {hour} * * * /bin/sh -c '{wrapped}' >> {log_path()} 2>&1 {CRON_MARKER}"
+    )
+
+
+# --- log parsing ---
+
+
+def parse_routine_log(text: str) -> dict | None:
+    """Last run from the marker lines: {'started': iso, 'exit_code': int|None}."""
+    started: str | None = None
+    exit_code: int | None = None
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith(RUN_START_PREFIX):
+            started = line[len(RUN_START_PREFIX) :].strip()
+            exit_code = None  # a new run resets the previous run's exit
+        elif line.startswith(RUN_EXIT_PREFIX) and started is not None:
+            tail = line[len(RUN_EXIT_PREFIX) :].strip()
+            exit_code = int(tail) if tail.lstrip("-").isdigit() else None
+    if started is None:
+        return None
+    return {"started": started, "exit_code": exit_code}
+
+
+def _read_log_tail(max_bytes: int = 65536) -> str:
+    path = log_path()
+    if not path.is_file():
+        return ""
+    try:
+        with path.open("rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            handle.seek(max(0, size - max_bytes))
+            return handle.read().decode("utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+# --- launchd state ---
+
+
+def _launchctl_state() -> dict | None:
+    if not _tool_exists("launchctl"):
+        return None
+    try:
+        proc = _run(["launchctl", "print", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"])
+    except Exception:
+        return None
+    if proc.returncode != 0:
+        return None
+    state: dict[str, str] = {}
+    for line in (proc.stdout or "").splitlines():
+        line = line.strip()
+        if line.startswith("state = "):
+            state["state"] = line.split("=", 1)[1].strip()
+        elif line.startswith("last exit code = "):
+            state["last_exit_code"] = line.split("=", 1)[1].strip()
+    return state or None
+
+
+# --- install / uninstall / status ---
+
+
+def _install_darwin(time_str: str, command: str) -> tuple[dict, int]:
+    plist_file = launchd_plist_path()
+    plist_file.parent.mkdir(parents=True, exist_ok=True)
+    log_path().parent.mkdir(parents=True, exist_ok=True)
+    if plist_file.exists():
+        # Re-install: unload the old job first so the new time/command takes.
+        _bootout_quietly()
+    plist_file.write_bytes(plistlib.dumps(build_launchd_plist(time_str, command)))
+    loaded = False
+    note = None
+    bootstrap = _run(["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_file)])
+    if bootstrap.returncode == 0:
+        loaded = True
+    else:
+        legacy = _run(["launchctl", "load", str(plist_file)])
+        if legacy.returncode == 0:
+            loaded = True
+            note = "loaded via legacy `launchctl load` (bootstrap unavailable)"
+        else:
+            note = (
+                "plist written but launchctl could not load it now; "
+                "launchd picks it up at next login"
+            )
+    payload = {
+        "installed": True,
+        "loaded": loaded,
+        "scheduler": "launchd",
+        "unit": str(plist_file),
+    }
+    if note:
+        payload["note"] = note
+    return payload, 0
+
+
+def _bootout_quietly() -> None:
+    res = _run(["launchctl", "bootout", f"gui/{os.getuid()}/{LAUNCHD_LABEL}"])
+    if res.returncode != 0:
+        _run(["launchctl", "unload", str(launchd_plist_path())])
+
+
+def _install_systemd(time_str: str, command: str) -> tuple[dict, int]:
+    unit_dir = systemd_unit_dir()
+    unit_dir.mkdir(parents=True, exist_ok=True)
+    log_path().parent.mkdir(parents=True, exist_ok=True)
+    systemd_service_path().write_text(build_systemd_service(command), encoding="utf-8")
+    systemd_timer_path().write_text(build_systemd_timer(time_str), encoding="utf-8")
+    _run(["systemctl", "--user", "daemon-reload"])
+    enable = _run(["systemctl", "--user", "enable", "--now", f"{SYSTEMD_UNIT}.timer"])
+    payload = {
+        "installed": True,
+        "loaded": enable.returncode == 0,
+        "scheduler": "systemd",
+        "unit": str(systemd_timer_path()),
+    }
+    if enable.returncode != 0:
+        payload["note"] = "unit files written but `systemctl --user enable --now` failed"
+    return payload, 0
+
+
+def _read_crontab() -> str:
+    listing = _run(["crontab", "-l"])
+    return listing.stdout if listing.returncode == 0 else ""
+
+
+def _install_cron(time_str: str, command: str) -> tuple[dict, int]:
+    log_path().parent.mkdir(parents=True, exist_ok=True)
+    kept = [
+        line for line in _read_crontab().splitlines() if CRON_MARKER not in line
+    ]
+    kept.append(build_cron_line(time_str, command))
+    write = _run(["crontab", "-"], input_text="\n".join(kept) + "\n")
+    payload = {
+        "installed": write.returncode == 0,
+        "loaded": write.returncode == 0,
+        "scheduler": "cron",
+        "unit": "crontab",
+        "note": (
+            "cron has no missed-run coalescing: if the machine is asleep at "
+            f"{time_str}, that day's run is skipped"
+        ),
+    }
+    return payload, 0 if write.returncode == 0 else 1
+
+
+def install_routine(
+    time_str: str = DEFAULT_TIME,
+    command: str | None = None,
+    platform: str | None = None,
+) -> tuple[dict, int]:
+    hour, minute = parse_time(time_str)  # validates; raises ValueError
+    time_str = f"{hour:02d}:{minute:02d}"
+    explicit_command = command is not None
+    command = command or DEFAULT_COMMAND
+    if not explicit_command and _resolve_claude() is None:
+        # The default job is headless Claude; installing it without the binary
+        # would just fail silently every morning. Refuse, and hand the user
+        # the exact command to wire into whatever scheduler they do have.
+        return (
+            {
+                "installed": False,
+                "warning": (
+                    "`claude` binary not found on PATH — the default routine runs "
+                    "the edition skill headless via Claude Code"
+                ),
+                "command": command,
+                "hint": (
+                    "install Claude Code (https://claude.com/claude-code) and retry, "
+                    "pass your own --command, or wire the command above into your "
+                    "own scheduler"
+                ),
+            },
+            1,
+        )
+    scheduler = detect_scheduler(platform)
+    if scheduler == "launchd":
+        payload, code = _install_darwin(time_str, command)
+    elif scheduler == "systemd":
+        payload, code = _install_systemd(time_str, command)
+    elif scheduler == "cron":
+        payload, code = _install_cron(time_str, command)
+    else:
+        return (
+            {
+                "installed": False,
+                "warning": "no supported scheduler found (need launchd, systemd --user, or crontab)",
+                "command": command,
+                "hint": "wire the command above into your platform's scheduler",
+            },
+            1,
+        )
+    payload.update(
+        {
+            "schedule": {
+                "time": time_str,
+                "semantics": schedule_semantics(scheduler, time_str),
+            },
+            "command": command,
+            "log": str(log_path()),
+        }
+    )
+    return payload, code
+
+
+def _installed_scheduler() -> str | None:
+    """Which scheduler actually has the routine, judged from artifacts on disk."""
+    if launchd_plist_path().is_file():
+        return "launchd"
+    if systemd_timer_path().is_file():
+        return "systemd"
+    if _tool_exists("crontab") and any(
+        CRON_MARKER in line for line in _read_crontab().splitlines()
+    ):
+        return "cron"
+    return None
+
+
+def _schedule_from_launchd() -> tuple[str | None, str | None]:
+    try:
+        with launchd_plist_path().open("rb") as handle:
+            data = plistlib.load(handle)
+    except Exception:
+        return None, None
+    interval = data.get("StartCalendarInterval") or {}
+    time_str = None
+    if isinstance(interval, dict) and "Hour" in interval and "Minute" in interval:
+        time_str = f"{int(interval['Hour']):02d}:{int(interval['Minute']):02d}"
+    command = None
+    args = data.get("ProgramArguments") or []
+    if len(args) == 3 and args[0] == "/bin/sh":
+        command = _unwrap_command(args[2]) or args[2]
+    return time_str, command
+
+
+def _schedule_from_systemd() -> tuple[str | None, str | None]:
+    time_str = None
+    command = None
+    try:
+        timer_text = systemd_timer_path().read_text(encoding="utf-8")
+        match = re.search(r"OnCalendar=\*-\*-\* (\d{2}):(\d{2}):\d{2}", timer_text)
+        if match:
+            time_str = f"{match.group(1)}:{match.group(2)}"
+    except OSError:
+        pass
+    try:
+        service_text = systemd_service_path().read_text(encoding="utf-8")
+        match = re.search(r'ExecStart=/bin/sh -c "(.*)"', service_text)
+        if match:
+            unescaped = (
+                match.group(1).replace('\\"', '"').replace("%%", "%").replace("\\\\", "\\")
+            )
+            command = _unwrap_command(unescaped) or unescaped
+    except OSError:
+        pass
+    return time_str, command
+
+
+def _schedule_from_cron() -> tuple[str | None, str | None]:
+    for line in _read_crontab().splitlines():
+        if CRON_MARKER not in line:
+            continue
+        fields = line.split()
+        if len(fields) >= 5:
+            try:
+                return f"{int(fields[1]):02d}:{int(fields[0]):02d}", None
+            except ValueError:
+                return None, None
+    return None, None
+
+
+def routine_status() -> dict:
+    scheduler = _installed_scheduler()
+    if scheduler is None:
+        return {
+            "installed": False,
+            "scheduler": None,
+            "log": str(log_path()),
+            "hint": "schedule the daily edition with `morning-paper routine install`",
+        }
+    if scheduler == "launchd":
+        time_str, command = _schedule_from_launchd()
+    elif scheduler == "systemd":
+        time_str, command = _schedule_from_systemd()
+    else:
+        time_str, command = _schedule_from_cron()
+    payload: dict[str, object] = {
+        "installed": True,
+        "scheduler": scheduler,
+        "schedule": {
+            "time": time_str,
+            "semantics": schedule_semantics(scheduler, time_str or DEFAULT_TIME),
+        },
+        "command": command,
+        "last_run": parse_routine_log(_read_log_tail()),
+        "next_fire": next_fire(time_str) if time_str else None,
+        "log": str(log_path()),
+    }
+    if scheduler == "launchd":
+        state = _launchctl_state()
+        if state:
+            payload["launchd"] = state
+        else:
+            payload["launchd"] = {"state": "not loaded"}
+    return payload
+
+
+def uninstall_routine() -> tuple[dict, int]:
+    scheduler = _installed_scheduler()
+    if scheduler is None:
+        # Idempotent: uninstalling an absent routine is a no-op, not an error.
+        return {"uninstalled": False, "installed": False, "note": "routine was not installed"}, 0
+    if scheduler == "launchd":
+        _bootout_quietly()
+        launchd_plist_path().unlink(missing_ok=True)
+    elif scheduler == "systemd":
+        _run(["systemctl", "--user", "disable", "--now", f"{SYSTEMD_UNIT}.timer"])
+        systemd_timer_path().unlink(missing_ok=True)
+        systemd_service_path().unlink(missing_ok=True)
+        _run(["systemctl", "--user", "daemon-reload"])
+    elif scheduler == "cron":
+        kept = [line for line in _read_crontab().splitlines() if CRON_MARKER not in line]
+        text = "\n".join(kept)
+        _run(["crontab", "-"], input_text=text + "\n" if text else "\n")
+    return {"uninstalled": True, "scheduler": scheduler, "log": str(log_path())}, 0
+
+
+def routine_doctor_summary() -> dict:
+    """File-checks only (no subprocess) so doctor stays fast and offline."""
+    scheduler = None
+    time_str = None
+    if launchd_plist_path().is_file():
+        scheduler = "launchd"
+        time_str, _ = _schedule_from_launchd()
+    elif systemd_timer_path().is_file():
+        scheduler = "systemd"
+        time_str, _ = _schedule_from_systemd()
+    summary: dict[str, object] = {"installed": scheduler is not None, "scheduler": scheduler}
+    if time_str:
+        summary["time"] = time_str
+    return summary
+
+
+# --- CLI ---
+
+
+def routine_command(args: list[str]) -> int:
+    usage = (
+        "usage: morning-paper routine <install|status|uninstall> "
+        "[--time HH:MM] [--command CMD]"
+    )
+    if not args or args[0] in {"-h", "--help"}:
+        print(usage)
+        return 0
+    action, rest = args[0], args[1:]
+    time_str = DEFAULT_TIME
+    command: str | None = None
+    index = 0
+    while index < len(rest):
+        arg = rest[index]
+        if arg in {"-h", "--help"}:
+            print(usage)
+            return 0
+        if arg == "--time" and index + 1 < len(rest):
+            time_str = rest[index + 1]
+            index += 2
+            continue
+        if arg == "--command" and index + 1 < len(rest):
+            command = rest[index + 1]
+            index += 2
+            continue
+        print(f"unknown routine argument: {arg}", file=sys.stderr)
+        return 2
+    if action == "install":
+        try:
+            payload, code = install_routine(time_str, command)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        if not payload.get("installed"):
+            warning = payload.get("warning")
+            if warning:
+                print(f"warning: {warning}", file=sys.stderr)
+            print(f"command to schedule yourself: {payload.get('command')}", file=sys.stderr)
+        print(json.dumps(payload, indent=2))
+        return code
+    if action == "status":
+        print(json.dumps(routine_status(), indent=2))
+        return 0
+    if action == "uninstall":
+        payload, code = uninstall_routine()
+        print(json.dumps(payload, indent=2))
+        return code
+    print(f"unknown routine action: {action}", file=sys.stderr)
+    print(usage, file=sys.stderr)
+    return 2

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -1,0 +1,416 @@
+from __future__ import annotations
+
+import io
+import json
+import os
+import plistlib
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+from morning_paper import cli, routine
+
+
+class FakeRun:
+    """Records every scheduler subprocess call; no launchctl/systemctl/crontab in CI."""
+
+    def __init__(self, fail_prefixes: tuple[tuple[str, ...], ...] = (), stdout_map=None):
+        self.calls: list[list[str]] = []
+        self.inputs: list[str | None] = []
+        self.fail_prefixes = fail_prefixes
+        self.stdout_map = stdout_map or {}
+
+    def __call__(self, args: list[str], input_text: str | None = None):
+        self.calls.append(list(args))
+        self.inputs.append(input_text)
+        returncode = 0
+        for prefix in self.fail_prefixes:
+            if tuple(args[: len(prefix)]) == prefix:
+                returncode = 1
+        stdout = ""
+        for prefix, text in self.stdout_map.items():
+            if tuple(args[: len(prefix)]) == prefix:
+                stdout = text
+        return subprocess.CompletedProcess(args, returncode, stdout=stdout, stderr="")
+
+
+class RoutineHomeTestCase(unittest.TestCase):
+    """Every test runs against a throwaway HOME so no real agent dirs are touched."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp.name)
+        patcher = patch.dict(os.environ, {"HOME": str(self.home)})
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(self._tmp.cleanup)
+
+
+class LaunchdPlistTests(RoutineHomeTestCase):
+    def test_default_plist_content(self) -> None:
+        data = routine.build_launchd_plist()
+        self.assertEqual(data["Label"], "com.morning-paper.edition")
+        # The chosen semantics: StartCalendarInterval fires daily at 05:00
+        # local time; launchd coalesces runs missed during sleep into one
+        # run at the next wake. RunAtLoad stays False so install never
+        # triggers an immediate edition.
+        self.assertEqual(data["StartCalendarInterval"], {"Hour": 5, "Minute": 0})
+        self.assertIs(data["RunAtLoad"], False)
+        self.assertTrue(data["StandardOutPath"].endswith("morning-paper/routine.log"))
+        self.assertEqual(data["StandardOutPath"], data["StandardErrorPath"])
+        self.assertEqual(data["ProgramArguments"][:2], ["/bin/sh", "-c"])
+        wrapped = data["ProgramArguments"][2]
+        self.assertIn('claude -p "Run the morning-paper edition skill', wrapped)
+        self.assertIn("--permission-mode acceptEdits", wrapped)
+        self.assertIn(routine.RUN_START_PREFIX, wrapped)
+        self.assertIn(routine.RUN_EXIT_PREFIX, wrapped)
+        self.assertIn("PATH", data["EnvironmentVariables"])
+
+    def test_custom_time_and_command(self) -> None:
+        data = routine.build_launchd_plist("06:30", "echo hello")
+        self.assertEqual(data["StartCalendarInterval"], {"Hour": 6, "Minute": 30})
+        self.assertIn("echo hello; rc=$?;", data["ProgramArguments"][2])
+
+    def test_plist_serializes(self) -> None:
+        blob = plistlib.dumps(routine.build_launchd_plist())
+        reread = plistlib.loads(blob)
+        self.assertEqual(reread["Label"], "com.morning-paper.edition")
+
+    def test_unwrap_roundtrip(self) -> None:
+        for command in (routine.DEFAULT_COMMAND, "echo hi", "my-tool --flag 'x y'"):
+            self.assertEqual(routine._unwrap_command(routine._wrap_command(command)), command)
+
+    def test_invalid_time_rejected(self) -> None:
+        for bad in ("25:00", "05:61", "5", "morning", "5:0"):
+            with self.assertRaises(ValueError):
+                routine.parse_time(bad)
+
+
+class UnitGenerationTests(RoutineHomeTestCase):
+    def test_systemd_timer_persistent(self) -> None:
+        timer = routine.build_systemd_timer("05:00")
+        self.assertIn("OnCalendar=*-*-* 05:00:00", timer)
+        self.assertIn("Persistent=true", timer)
+        self.assertIn("WantedBy=timers.target", timer)
+
+    def test_systemd_service_escapes_percent(self) -> None:
+        service = routine.build_systemd_service("echo hi")
+        self.assertIn("ExecStart=/bin/sh -c", service)
+        self.assertIn("echo hi; rc=$?;", service)
+        # the date format's % signs must be doubled for systemd
+        self.assertIn("%%Y-%%m-%%d", service)
+        self.assertNotIn("%Y-%m-%d", service.replace("%%", ""))
+        self.assertIn(f"StandardOutput=append:{routine.log_path()}", service)
+
+    def test_cron_line_escapes_and_notes_schedule(self) -> None:
+        line = routine.build_cron_line("06:15", "echo hi")
+        self.assertTrue(line.startswith("15 6 * * * /bin/sh -c '"))
+        self.assertTrue(line.endswith(routine.CRON_MARKER))
+        self.assertIn(r"\%Y", line)  # cron eats bare %
+        self.assertIn("'\\''", line)  # single quotes inside the single-quoted command
+
+
+class InstallDarwinTests(RoutineHomeTestCase):
+    def _install(self, argv: list[str], fake: FakeRun):
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/local/bin/claude"):
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                rc = cli.main(argv)
+        return rc, stdout.getvalue(), stderr.getvalue()
+
+    def test_install_writes_plist_and_bootstraps(self) -> None:
+        fake = FakeRun()
+        rc, out, _ = self._install(["routine", "install"], fake)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertTrue(payload["installed"])
+        self.assertTrue(payload["loaded"])
+        self.assertEqual(payload["scheduler"], "launchd")
+        self.assertEqual(payload["schedule"]["time"], "05:00")
+        self.assertIn("coalesced", payload["schedule"]["semantics"])
+        self.assertEqual(payload["command"], routine.DEFAULT_COMMAND)
+        plist_file = self.home / "Library" / "LaunchAgents" / "com.morning-paper.edition.plist"
+        self.assertTrue(plist_file.is_file())
+        with plist_file.open("rb") as handle:
+            data = plistlib.load(handle)
+        self.assertEqual(data["StartCalendarInterval"], {"Hour": 5, "Minute": 0})
+        bootstrap_calls = [c for c in fake.calls if c[:2] == ["launchctl", "bootstrap"]]
+        self.assertEqual(len(bootstrap_calls), 1)
+        self.assertTrue(bootstrap_calls[0][2].startswith("gui/"))
+
+    def test_install_custom_time(self) -> None:
+        fake = FakeRun()
+        rc, out, _ = self._install(["routine", "install", "--time", "6:45"], fake)
+        self.assertEqual(rc, 0)
+        self.assertEqual(json.loads(out)["schedule"]["time"], "06:45")
+
+    def test_install_falls_back_to_legacy_load(self) -> None:
+        fake = FakeRun(fail_prefixes=(("launchctl", "bootstrap"),))
+        rc, out, _ = self._install(["routine", "install"], fake)
+        self.assertEqual(rc, 0)
+        payload = json.loads(out)
+        self.assertTrue(payload["loaded"])
+        self.assertIn("legacy", payload["note"])
+        self.assertIn(["launchctl", "load", str(routine.launchd_plist_path())], fake.calls)
+
+    def test_install_bad_time_exits_2(self) -> None:
+        fake = FakeRun()
+        rc, _, err = self._install(["routine", "install", "--time", "25:99"], fake)
+        self.assertEqual(rc, 2)
+        self.assertIn("invalid --time", err)
+        self.assertEqual(fake.calls, [])
+
+
+class NoClaudeBinaryTests(RoutineHomeTestCase):
+    def test_install_without_claude_warns_and_shows_command(self) -> None:
+        fake = FakeRun()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value=None):
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                rc = cli.main(["routine", "install"])
+        self.assertEqual(rc, 1)
+        payload = json.loads(stdout.getvalue())
+        self.assertFalse(payload["installed"])
+        self.assertIn("claude", payload["warning"])
+        self.assertEqual(payload["command"], routine.DEFAULT_COMMAND)
+        self.assertIn("`claude` binary not found", stderr.getvalue())
+        self.assertIn(routine.DEFAULT_COMMAND, stderr.getvalue())
+        self.assertFalse(routine.launchd_plist_path().exists())
+        self.assertEqual(fake.calls, [])
+
+    def test_explicit_command_skips_the_claude_check(self) -> None:
+        fake = FakeRun()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value=None):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                rc = cli.main(["routine", "install", "--command", "my-own-editor --go"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["installed"])
+        self.assertEqual(payload["command"], "my-own-editor --go")
+
+
+class InstallLinuxTests(RoutineHomeTestCase):
+    def test_systemd_user_timer_path(self) -> None:
+        fake = FakeRun()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="linux"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/bin/claude"), patch.object(
+            routine, "_tool_exists", lambda name: name == "systemctl"
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                rc = cli.main(["routine", "install", "--time", "07:00"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["scheduler"], "systemd")
+        timer = routine.systemd_timer_path().read_text(encoding="utf-8")
+        self.assertIn("OnCalendar=*-*-* 07:00:00", timer)
+        self.assertIn("Persistent=true", timer)
+        self.assertTrue(routine.systemd_service_path().is_file())
+        self.assertIn(["systemctl", "--user", "daemon-reload"], fake.calls)
+        self.assertIn(
+            ["systemctl", "--user", "enable", "--now", "morning-paper-edition.timer"],
+            fake.calls,
+        )
+
+    def test_cron_fallback_when_no_systemd(self) -> None:
+        fake = FakeRun(stdout_map={("crontab", "-l"): "0 9 * * * existing-job\n"})
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="linux"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/bin/claude"), patch.object(
+            routine, "_tool_exists", lambda name: name == "crontab"
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                rc = cli.main(["routine", "install"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["scheduler"], "cron")
+        self.assertIn("no missed-run coalescing", payload["note"])
+        written = fake.inputs[-1]
+        self.assertIn("0 9 * * * existing-job", written)
+        self.assertIn(routine.CRON_MARKER, written)
+        self.assertTrue(any("0 5 * * *" in line for line in written.splitlines()))
+
+
+class StatusTests(RoutineHomeTestCase):
+    LOG = (
+        "[morning-paper routine] start 2026-06-11T05:00:01-0700\n"
+        "some claude output\n"
+        "[morning-paper routine] exit 1\n"
+        "[morning-paper routine] start 2026-06-12T05:00:02-0700\n"
+        "edition rendered\n"
+        "[morning-paper routine] exit 0\n"
+    )
+
+    def test_parse_routine_log_takes_last_run(self) -> None:
+        parsed = routine.parse_routine_log(self.LOG)
+        self.assertEqual(parsed, {"started": "2026-06-12T05:00:02-0700", "exit_code": 0})
+
+    def test_parse_routine_log_run_in_flight(self) -> None:
+        text = self.LOG + "[morning-paper routine] start 2026-06-13T05:00:00-0700\n"
+        parsed = routine.parse_routine_log(text)
+        self.assertEqual(parsed["started"], "2026-06-13T05:00:00-0700")
+        self.assertIsNone(parsed["exit_code"])
+
+    def test_parse_routine_log_empty(self) -> None:
+        self.assertIsNone(routine.parse_routine_log(""))
+        self.assertIsNone(routine.parse_routine_log("unrelated noise\n"))
+
+    def test_status_not_installed(self) -> None:
+        with patch.object(routine, "_run", FakeRun()), patch.object(
+            routine, "_tool_exists", lambda name: False
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                rc = cli.main(["routine", "status"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertFalse(payload["installed"])
+        self.assertIsNone(payload["scheduler"])
+        self.assertIn("routine install", payload["hint"])
+
+    def test_status_installed_launchd(self) -> None:
+        # install (mocked), then write a log and ask for status
+        install_fake = FakeRun()
+        with patch.object(routine, "_run", install_fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/local/bin/claude"):
+            with redirect_stdout(io.StringIO()):
+                cli.main(["routine", "install", "--time", "05:30"])
+        routine.log_path().parent.mkdir(parents=True, exist_ok=True)
+        routine.log_path().write_text(self.LOG, encoding="utf-8")
+        status_fake = FakeRun(
+            stdout_map={
+                ("launchctl", "print"): (
+                    "gui/501/com.morning-paper.edition = {\n"
+                    "\tstate = waiting\n"
+                    "\tlast exit code = 0\n"
+                    "}\n"
+                )
+            }
+        )
+        with patch.object(routine, "_run", status_fake), patch.object(
+            routine, "_tool_exists", lambda name: name == "launchctl"
+        ):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout):
+                rc = cli.main(["routine", "status"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["installed"])
+        self.assertEqual(payload["scheduler"], "launchd")
+        self.assertEqual(payload["schedule"]["time"], "05:30")
+        self.assertEqual(payload["command"], routine.DEFAULT_COMMAND)
+        self.assertEqual(payload["last_run"]["started"], "2026-06-12T05:00:02-0700")
+        self.assertEqual(payload["last_run"]["exit_code"], 0)
+        self.assertEqual(payload["launchd"]["state"], "waiting")
+        self.assertTrue(payload["next_fire"].count("05:30") == 1)
+        self.assertEqual(payload["log"], str(routine.log_path()))
+
+    def test_next_fire_rolls_to_tomorrow(self) -> None:
+        from datetime import datetime, timezone
+
+        now = datetime(2026, 6, 12, 9, 0, tzinfo=timezone.utc)
+        self.assertEqual(routine.next_fire("05:00", now=now), "2026-06-13T05:00+00:00")
+        self.assertEqual(routine.next_fire("10:00", now=now), "2026-06-12T10:00+00:00")
+
+
+class UninstallTests(RoutineHomeTestCase):
+    def test_uninstall_is_idempotent(self) -> None:
+        fake = FakeRun()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/local/bin/claude"), patch.object(
+            routine, "_tool_exists", lambda name: name == "launchctl"
+        ):
+            with redirect_stdout(io.StringIO()):
+                cli.main(["routine", "install"])
+            self.assertTrue(routine.launchd_plist_path().is_file())
+
+            first, second = io.StringIO(), io.StringIO()
+            with redirect_stdout(first):
+                rc1 = cli.main(["routine", "uninstall"])
+            with redirect_stdout(second):
+                rc2 = cli.main(["routine", "uninstall"])
+        self.assertEqual((rc1, rc2), (0, 0))
+        payload1 = json.loads(first.getvalue())
+        self.assertTrue(payload1["uninstalled"])
+        self.assertEqual(payload1["scheduler"], "launchd")
+        self.assertFalse(routine.launchd_plist_path().exists())
+        payload2 = json.loads(second.getvalue())
+        self.assertFalse(payload2["uninstalled"])
+        self.assertFalse(payload2["installed"])
+        bootout_calls = [c for c in fake.calls if c[:2] == ["launchctl", "bootout"]]
+        self.assertTrue(bootout_calls)
+
+    def test_uninstall_systemd_removes_units(self) -> None:
+        fake = FakeRun()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="linux"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/bin/claude"), patch.object(
+            routine, "_tool_exists", lambda name: name == "systemctl"
+        ):
+            with redirect_stdout(io.StringIO()):
+                cli.main(["routine", "install"])
+                rc = cli.main(["routine", "uninstall"])
+        self.assertEqual(rc, 0)
+        self.assertFalse(routine.systemd_timer_path().exists())
+        self.assertFalse(routine.systemd_service_path().exists())
+        self.assertIn(
+            ["systemctl", "--user", "disable", "--now", "morning-paper-edition.timer"],
+            fake.calls,
+        )
+
+
+class DoctorRoutineTests(RoutineHomeTestCase):
+    def test_doctor_json_reports_routine_absent_without_error(self) -> None:
+        with patch.object(routine, "_tool_exists", lambda name: False):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                with patch.object(cli, "_print_update_notice"):
+                    rc = cli.main(["doctor", "--json"])
+        payload = json.loads(stdout.getvalue())
+        self.assertIn("routine", payload)
+        self.assertFalse(payload["routine"]["installed"])
+        self.assertIsNone(payload["routine"]["scheduler"])
+        # absence must not break doctor: status reflects renderer/modules only
+        self.assertIn(payload["status"], {"ok", "fallback-only", "broken"})
+        self.assertIn(rc, {0, 1})
+
+    def test_doctor_json_reports_routine_installed(self) -> None:
+        with patch.object(routine, "_run", FakeRun()), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/local/bin/claude"):
+            with redirect_stdout(io.StringIO()):
+                cli.main(["routine", "install", "--time", "06:00"])
+        stdout = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+            with patch.object(cli, "_print_update_notice"):
+                cli.main(["doctor", "--json"])
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["routine"]["installed"])
+        self.assertEqual(payload["routine"]["scheduler"], "launchd")
+        self.assertEqual(payload["routine"]["time"], "06:00")
+
+    def test_doctor_human_output_mentions_routine(self) -> None:
+        with patch.object(routine, "_tool_exists", lambda name: False):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                with patch.object(cli, "_print_update_notice"):
+                    cli.main(["doctor"])
+        self.assertIn("routine: not installed", stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`morning-paper routine` — the scheduling ladder's Tier 1. The editor is an agent, so the scheduled job is simply `claude -p "Run the morning-paper edition skill: …" --permission-mode acceptEdits` run headless against the user's existing subscription. No extra API key, no daemon of ours.

## The commands

- **`routine install [--time HH:MM] [--command CMD]`** — default 05:00. macOS: a LaunchAgent at `~/Library/LaunchAgents/com.morning-paper.edition.plist` using `StartCalendarInterval` (`{Hour, Minute}`), chosen because launchd **coalesces runs missed during sleep into one run on the next wake** — the paper is ready when the laptop opens, instead of being skipped (the WHY is a comment in the plist builder). `RunAtLoad` false (install never fires an immediate run), stdout/stderr to `~/.local/share/morning-paper/routine.log`, the installing user's `PATH` frozen into the job (launchd's minimal PATH can't find `claude`), loaded via `launchctl bootstrap gui/$UID` with a legacy `launchctl load` fallback. Linux: systemd user timer with `Persistent=true`; cron fallback line carries the honest note that cron has no coalescing. If `claude` is not on PATH (and no `--command` was given) the install **refuses**, warns, and prints the exact command to wire into your own scheduler.
- **`routine status`** — JSON: installed?, scheduler, schedule (time + plain-language semantics), the raw command (unwrapped from the unit), last run parsed from timestamped run markers wrapped around every invocation in the log (+ `launchctl print` state on macOS), computed next fire, log path.
- **`routine uninstall`** — clean removal, idempotent (absent routine → no-op, exit 0).

All three speak JSON.

## Also

- `doctor` reports the routine (file-checks only, stays fast/offline): `"routine"` key in `--json`, a human line otherwise — absence is informational, never an error.
- README: the four-tier ladder, one paragraph each (Tier 0 say-"paper"; Tier 1 `routine install` laptop-wake magic; Tier 2 always-on + `pmset repeat wakeorpoweron` note; Tier 3 cloud-compose split). docs/composing.md pointer; setup skill section 6 replaced with the real command + the ladder offer. Edition skill untouched.
- Version 0.5.1 (pyproject / `__init__` / plugin.json) + CHANGELOG.

## Tests

- 27 new tests, **113 total** (86 baseline), all green. No real `launchctl`/`systemctl`/`crontab` runs in CI — every scheduler call goes through a patchable `_run` seam, and every test runs against a throwaway `$HOME`.
- Covered: plist content (label, calendar interval, RunAtLoad, log paths, wrapped command), systemd unit generation (`Persistent=true`, `%%`-escaping for systemd, `\%` + `'\''` escaping for cron), install flows on both platforms, the bootstrap→legacy-load fallback, run-marker log parsing (last run, in-flight run, empty log), status JSON, uninstall idempotence, the no-claude-binary warning path, and doctor's routine report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)