### PR TITLE
The defluff pass: voice as an owned preference

### DIFF
--- a/skills/edition/SKILL.md
+++ b/skills/edition/SKILL.md
@@ -34,13 +34,21 @@ paper.
      typeset; not summaries.
    - Every claim traceable to collected data. A missing source prints
      "not configured". NEVER fabricate a number.
-4. **Budget.** `morning-paper estimate draft.md` — fit `page_budget` ±2 by
+4. **The defluff pass (mandatory when `preferences/voice.md` exists, recommended always).**
+   Re-read your draft as an editor cutting for a paper where every word
+   costs the reader time: omit needless words (Strunk), kill decoration and
+   restatement, keep every fact that enables action. Aim: same information,
+   markedly fewer words — then spend the reclaimed space on MORE useful
+   context, not whitespace. The reader's voice preferences in
+   `preferences/voice.md` override these defaults; honor them exactly.
+
+5. **Budget.** `morning-paper estimate draft.md` — fit `page_budget` ±2 by
    cutting the weakest material, never by shrinking type.
-5. **Render.** `morning-paper render draft.md --style <their style> --palette
+6. **Render.** `morning-paper render draft.md --style <their style> --palette
    <their palette> --date <today> --slug edition`.
-6. **QA.** Rasterize page 1 + one inner page (`pdftoppm -png -r 60`) and look:
+7. **QA.** Rasterize page 1 + one inner page (`pdftoppm -png -r 60`) and look:
    no overflow, no missing glyphs (tofu), footers present.
-7. **Deliver.** Their saved print command (duplex flag and all), or just hand
+8. **Deliver.** Their saved print command (duplex flag and all), or just hand
    back the PDF path. Archive markdown + html into `editions/<date>/`.
 
 ## Voice

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -33,6 +33,12 @@ Ask in 2-3 messages, not twenty. Capture:
   style (`morning-paper styles` lists the family of four — broadsheet,
   brief, field-card, zine; `broadsheet` is the default recommendation),
   palette (`color` for inkjets, `mono` for laser).
+- **Voice** — how should the paper talk? Offer three registers and write
+  the answer to `preferences/voice.md` in the newsroom: *dense operator*
+  (every word earns its ink; Strunk defluff pass each edition; maximum
+  context per inch), *classic newspaper* (measured, narrative), or
+  *explanatory* (more scaffolding, gentler). Density is a preference, not
+  a virtue — match the reader.
 - **Printer** — CUPS name (`lpstat -p`), duplex capable? Save the print
   command in the newsroom README.
 


### PR DESCRIPTION
Owner ruling: 20 pages/day means every word matters. The edition skill gains a mandatory Strunk-style revision pass (omit needless words; same information, fewer words; reclaimed space buys MORE context). Voice is a per-reader preference file (dense operator / classic newspaper / explanatory) the setup skill now asks about — density offered, never imposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)