### PR TITLE
The writing skill: Strunk, AI-tells, and what makes a page worth reading

### DIFF
--- a/docs/composing.md
+++ b/docs/composing.md
@@ -4,6 +4,10 @@ The render seam is the contract between *judgment* and *typesetting*: an agent
 (or a human) writes plain markdown; the engine typesets it into a print-ready
 PDF through a style pack and a palette. The composer never writes CSS.
 
+Prose quality has its own contract: `skills/writing/SKILL.md` carries the
+revision discipline (Strunk per-sentence checks, the AI-tells kill list)
+that every composed document should pass before it reaches `render`.
+
 ```bash
 morning-paper render brief.md --style brief --palette mono
 morning-paper render call-card.md --style field-card --palette color

--- a/skills/edition/SKILL.md
+++ b/skills/edition/SKILL.md
@@ -34,13 +34,13 @@ paper.
      typeset; not summaries.
    - Every claim traceable to collected data. A missing source prints
      "not configured". NEVER fabricate a number.
-4. **The defluff pass (mandatory when `preferences/voice.md` exists, recommended always).**
-   Re-read your draft as an editor cutting for a paper where every word
-   costs the reader time: omit needless words (Strunk), kill decoration and
-   restatement, keep every fact that enables action. Aim: same information,
-   markedly fewer words — then spend the reclaimed space on MORE useful
-   context, not whitespace. The reader's voice preferences in
-   `preferences/voice.md` override these defaults; honor them exactly.
+4. **The revision pass (mandatory when `preferences/voice.md` exists, recommended always).**
+   Load `skills/writing` and run its discipline over the draft: the Strunk
+   per-sentence checks, the AI-tells kill list, the craft that makes a page
+   worth reading. Aim: same information, markedly fewer words — then spend
+   the reclaimed space on MORE useful context, not whitespace. The reader's
+   voice preferences in `preferences/voice.md` override every default in
+   that skill; honor them exactly.
 
 5. **Budget.** `morning-paper estimate draft.md` — fit `page_budget` ±2 by
    cutting the weakest material, never by shrinking type.

--- a/skills/writing/SKILL.md
+++ b/skills/writing/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: writing
+description: >
+  The revision discipline for anything the paper prints. Load while
+  composing an edition, a desk sheet, launch copy — any prose a reader
+  will hold. Compose for substance first; then run this pass.
+---
+
+# Morning Paper — The Writing Pass
+
+Twenty pages a day, and the reader pays for every word in minutes. This
+skill is the second pass: the editor's pen, not the writer's. It assumes
+a draft exists.
+
+## Compose, then revise
+
+Draft for substance: facts in, sources pinned, sections in spec order. Do
+not line-edit while composing — drafting and cutting use different judgment,
+and mixing them produces timid copy. When the draft is whole, change chairs.
+Re-read as an editor who did not write it and bills by the word. The checks
+below run sentence by sentence. A daily paper earns that.
+
+## Per-sentence checks (Strunk, distilled)
+
+From *The Elements of Style* (1918), rules cited by number.
+
+1. **Active voice (10).** "A survey of this region was made in 1900" →
+   "This region was surveyed in 1900." Passive survives only when the
+   acted-upon is the news.
+2. **Positive form (11).** "Did not pay any attention to" → "ignored."
+   "Not very often on time" → "usually late." The reader wants told what
+   is, not what is not.
+3. **Definite, specific, concrete (12).** "A period of unfavorable weather
+   set in" → "It rained every day for a week." Strunk calls this the surest
+   way to hold a reader. He is right.
+4. **Omit needless words (13).** "The question as to whether" → "whether";
+   "owing to the fact that" → "because"; "his story is a strange one" →
+   "his story is strange." A density rule, not a brevity rule: detail
+   stays, padding dies. Make every word tell.
+5. **Vary the sentence shape (14).** A page of clause—dash—elaboration
+   sentences goes sing-song no matter how good each one is. Recast every
+   third: a plain short sentence, a semicolon pair, a periodic build.
+6. **Parallel ideas, parallel form (15).** "First, the measure is unjust;
+   second, it is unconstitutional." Matching content gets matching shape.
+7. **Related words together (16).** Subject beside verb. An interpolation
+   longer than about six words between them becomes its own sentence.
+8. **Emphatic words last (18).** The end of the sentence is the position
+   of power; put the new fact there. Same law for the paragraph's last
+   sentence and the section's last paragraph.
+9. **One paragraph, one topic (8, 9).** The first sentence says which.
+10. **Signpost once (17).** Mark a summary or a source once, then stop
+    intercalating "as noted above" and "the paper observes."
+
+**Punctuation floor (1–6):** serial comma; both commas around a parenthetic
+phrase or neither; semicolon, not comma, between independent clauses; never
+break a sentence in two for fake punch. And an opening modifier must name
+its subject next (7) — "Walking to the printer, the queue jammed" is about
+a walking queue.
+
+**Word patrol (Chapter V keepers).** Cut on sight: *very* and *certainly*
+(use words that carry their own emphasis); *interesting* as a label (show
+the thing instead); *the fact that*, always; *as to whether*; *along these
+lines*; *factor*, *aspect*, *nature*, *character*, *system* as abstraction
+filler; *one of the most* as an opener; *worth while* as vague approval;
+*literally* propping up an exaggeration.
+
+## The kill list — current AI tells (June 2026)
+
+What readers now flag as machine prose, deadliest first. Vocabulary tells
+("delve," "tapestry," "testament") have largely faded from current models;
+the structural habits below survive every generation so far, Fable 5
+included — its launch reviews describe the default voice as fluent, tidy,
+editorially polished, and generic. This pass exists to cut exactly that.
+
+1. **Uniform cadence.** Sentences of 18–24 words, one after another, page
+   after page — the single most durable tell. Fix with sentence music
+   (below). Test: read a paragraph aloud; metronome means recast.
+2. **The unearned antithesis.** "It's not X, it's Y"; "not just X — Y."
+   Models reach for it once a paragraph. Budget: once per edition, and only
+   when the contrast is the news.
+   *Before:* "This isn't a pipeline problem — it's a trust problem."
+   *After:* "The pipeline is fine. Nobody trusts its numbers."
+3. **The tidy triplet.** "Fast, reliable, and affordable." Three-beat lists
+   as rhythm filler. If two items carry the weight, print two; if four,
+   four. A triplet must be a fact about the world, not a cadence.
+4. **Hedging clusters.** "It's worth noting that," "generally speaking,"
+   "arguably," "in many cases." A caveat is either information — keep it,
+   sharpened ("pending, not confirmed") — or defense. Cut defense.
+5. **Significance inflation.** "A testament to," "pivotal," "underscores,"
+   "marks a turning point," "evolving landscape." Includes the copulative
+   dodge: "serves as," "stands as," "boasts" where *is* belongs. Importance
+   rides on numbers, never adjectives.
+   *Before:* "The clean canary run underscores the system's robustness."
+   *After:* "The canary passed 23 checks. First clean sweep on record."
+6. **The summary-conclusion compulsion.** Closers that restate the piece:
+   "In the end…," "As X continues to evolve…," "one thing is clear." End on
+   the newest fact or the reader's move. When you're ready to stop, stop.
+7. **The participial analysis clause.** "…, highlighting the importance of
+   delivery truth." Judgment hung off a comma with no evidence attached.
+   Substantiate it or delete it.
+8. **The colon-subtitle reflex.** "Delivery Truth: Why the Ledger Matters."
+   Heads in this paper state the news: "The ledger caught its first failed
+   send."
+9. **Em-dash chains.** The dash is legal; three per paragraph is a
+   signature, especially the clause—dash—elaboration shape (rule 14 again).
+   Ration to roughly one dash construction per paragraph. Commas, colons,
+   and periods do the rest.
+10. **Abstraction where a detail exists.** *Before:* "a strong signal from
+    the funnel." *After:* "brian@lakeerieroof.com, a roofing-company
+    domain." The concrete noun is the credibility.
+11. **Symmetry everywhere.** Every list item the same length, every
+    paragraph the same three-sentence arc, every section the same close.
+    Vary on purpose. One item may be one word.
+12. **Throat-clearing openers.** "Great question." "Let's dive in." "Here's
+    the thing." The paper opens with the news.
+
+## What makes the page worth reading
+
+Cutting gets the paper read. These get it remembered.
+
+- **Sentence music** (Provost). Vary length on purpose. Short sentences
+  punch. A medium sentence carries the fact to where it lands. And once in
+  a while, when the material has earned it, a long sentence gathers its
+  clauses, builds, and sets the point down at the end, where the emphasis
+  lives. Then stop.
+- **Concrete detail is credibility** (Zinsser; Strunk 12). The odd specific
+  fact rescues a passage no styling can. Collect more detail than you
+  print; print the two details that prove you were there.
+- **The lede does work.** First sentence of every section: the newest,
+  most consequential thing, stated as a judgment the data can carry. Why
+  it matters and why today belong in the first two sentences, not after a
+  wind-up.
+- **Surprise, once.** One genuine observation per edition the reader did
+  not order — a pattern across sections, a number that contradicts the
+  story. Zinsser: surprise is the most refreshing element in nonfiction.
+- **One writer, one reader.** The paper is a person writing to a person.
+  "You" means the reader and their next move; "the paper" appears only
+  when the institution itself is the subject.
+- **Structure stays invisible** (McPhee). Shape moves the reader without
+  being seen. A page that explains its own organization has failed at it.
+- **The daily-format law.** The furniture is the constant; the judgment is
+  the news. Standing sections earn trust by being identical and earn
+  reading by saying something new inside. A stale item gets one flagged
+  line, never yesterday's paragraph. The day the prose could be last
+  week's, the paper is dead.
+
+## The honesty boundary
+
+Never trade accuracy for punch. A vivid wrong number is worse than a dull
+right one, because the vivid one gets acted on.
+
+- Punch up prose, never facts. If the tightened sentence claims more than
+  the data shows, the cut went too deep; restore the qualifier.
+- A real hedge is information. "Recovery emails sent, delivery pending" is
+  not fluff; it is the state of the world. Sharpen hedges, keep them.
+- Positive form (11) bows to truth: "none bounced" stays negative while
+  "delivered" is not yet a fact.
+- Concrete beats vague only when the concrete is verified. An invented
+  detail is fabrication wearing craft.
+
+## Register
+
+`preferences/voice.md` outranks every default in this skill. The pass
+adapts; it never imposes one voice.
+
+- **Dense operator** (the default these checks assume): cut to signal,
+  numbers carried in prose, zero ceremony.
+- **Classic / reading edition**: sentences may breathe. Keep every check,
+  raise the word budget; the music matters more here, not less.
+- **Explanatory**: teaching context is not fluff. Keep the why; cut only
+  restatement.
+
+Two things never adapt: the honesty boundary, and rule 13 — every register
+omits needless words; the registers just disagree on which words are needed.


### PR DESCRIPTION
## What

A research-backed writing-craft skill for the paper's composing agents, plus wiring.

- **`skills/writing/SKILL.md`** — the revision discipline any composing agent loads:
  - compose-then-revise (draft for substance, then change chairs and cut)
  - Strunk's *Elements of Style* (1918, public domain) distilled to ten per-sentence checks, a punctuation floor, and the Chapter V word patrol
  - a kill list of **current** AI tells (June 2026) with before/after fixes — uniform cadence, the unearned antithesis ("it's not X, it's Y"), tidy triplets, hedging clusters, significance inflation, summary-conclusion compulsion, em-dash chains, and five more
  - what makes the page worth reading: sentence music (Provost), concrete detail (Zinsser), working ledes, surprise, one-reader voice, invisible structure (McPhee), and the daily-format law
  - an explicit honesty boundary: punch up prose, never facts; a real hedge is information
  - register awareness: `preferences/voice.md` outranks the skill; the pass adapts rather than imposing one voice
- **`skills/edition/SKILL.md`** — the defluff step is now the revision pass: load `skills/writing`, run its discipline.
- **`docs/composing.md`** — one pointer: prose quality has its own contract.

## Why

Twenty pages a day, every word matters. The defluff step said "omit needless words (Strunk)" and stopped there; the agents had no shared definition of what to cut, what AI prose smells like in 2026, or what makes a repeated daily format stay alive. Now they do, in one place, written in the style it teaches.

## Research base

Strunk's full 1918 text (Project Gutenberg #37134); Wikipedia's *Signs of AI writing* catalog; June 2026 Fable 5 launch coverage (Willison, Lenny's, Noren's writer-focused tests); current detection craft (cadence uniformity as the most durable tell); Zinsser, Provost, McPhee. Full dossier with sources lives in the newsroom repo (`docs/writing-craft-research.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)