### PR TITLE
Pin the routine to the newsroom directory (0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-06-12
+
+### Fixed
+- **The scheduled edition now runs IN your newsroom directory.** `routine install` wrote scheduler jobs with no working directory, so the headless `claude -p` edition run started in `$HOME` and could not find the newsroom — `specs/`, `collectors/`, `editions/` were simply not there, and every scheduled paper composed blind. Install now captures the directory you install from (the contract: you install from your newsroom) and pins the job to it: launchd gets a `WorkingDirectory` plist key, the systemd service a `WorkingDirectory=` line, and the cron job a quote-safe `cd` into the newsroom inside its `sh -c` wrapper. `--workdir PATH` overrides the default (validated: must be an existing directory); the install JSON reports the resolved `workdir`, and `routine status` / `doctor` surface it where the artifact makes it cheap (the launchd plist). **Upgrading from 0.5.1: re-run `morning-paper routine install` from your newsroom** (or pass `--workdir`) — existing installs keep the old directory-less job until reinstalled
+
+### Changed
+- Edition skill, "Read the newsroom": the editor now also reads, when present, `memory/reads-ledger.md` (the cumulative record of everything already printed — repeating a read the owner already got is a hard fail; today's reads are appended when the paper ships), the most recent `editions/<date>/operator-answers.md` (triaged owner ink: deep-read picks, queue answers, steers — honored exactly), and checks an `inbox/scans/` directory for untriaged captures before composing
+
 ## [0.5.1] - 2026-06-12
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.5.1"
+version = "0.5.2"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/skills/edition/SKILL.md
+++ b/skills/edition/SKILL.md
@@ -24,7 +24,13 @@ paper.
    agent put it there on purpose). Staged items with a `contributor` name
    render with a FROM <NAME> kicker — the paper says who sent it in.
 2. **Read the newsroom.** `specs/*` (section contracts) and `preferences/*`
-   (reading weights, style notes). These outrank your taste.
+   (reading weights, style notes). These outrank your taste. Also read, when
+   present: `memory/reads-ledger.md` — the cumulative record of everything
+   already printed; repeating a read the owner already got is a hard fail,
+   and when today's paper ships, append today's reads to it. And the most
+   recent `editions/<date>/operator-answers.md` — triaged owner ink (deep-read
+   picks, queue answers, steers); honor it exactly. If the newsroom keeps an
+   `inbox/scans/` directory, check it for untriaged captures before composing.
 3. **Compose** one markdown document (raw HTML allowed; see the engine's
    docs/composing.md for the class vocabulary and `mp-bars`/`mp-spark`/
    `mp-stats` chart directives):

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/src/morning_paper/cli.py
+++ b/src/morning_paper/cli.py
@@ -47,7 +47,9 @@ Commands:
   estimate <file>   Page count for a markdown file, nothing written
   styles            List available styles and palettes
   routine           Schedule the daily edition (install [--time HH:MM]
-                    [--command CMD] | status | uninstall) — launchd/systemd/cron
+                    [--command CMD] [--workdir PATH] | status | uninstall) —
+                    launchd/systemd/cron; the run starts in the directory you
+                    install from (your newsroom)
   doctor            Check config, dependencies, and renderer status (--json, --strict)
   --version         Show installed version
 

--- a/src/morning_paper/routine.py
+++ b/src/morning_paper/routine.py
@@ -175,9 +175,13 @@ def next_fire(time_str: str, now: datetime | None = None) -> str:
 # --- unit generation (pure, fully testable) ---
 
 
-def build_launchd_plist(time_str: str = DEFAULT_TIME, command: str = DEFAULT_COMMAND) -> dict:
+def build_launchd_plist(
+    time_str: str = DEFAULT_TIME,
+    command: str = DEFAULT_COMMAND,
+    workdir: str | None = None,
+) -> dict:
     hour, minute = parse_time(time_str)
-    return {
+    plist: dict = {
         "Label": LAUNCHD_LABEL,
         # /bin/sh -c keeps the command a plain shell string the user can read
         # back out of the plist; launchd itself does no shell parsing.
@@ -200,6 +204,11 @@ def build_launchd_plist(time_str: str = DEFAULT_TIME, command: str = DEFAULT_COM
         "StandardOutPath": str(log_path()),
         "StandardErrorPath": str(log_path()),
     }
+    if workdir:
+        # launchd starts agents nowhere near the newsroom; without this key
+        # the headless editor cannot find specs/, collectors/, editions/.
+        plist["WorkingDirectory"] = workdir
+    return plist
 
 
 def _systemd_escape(command: str) -> str:
@@ -208,14 +217,18 @@ def _systemd_escape(command: str) -> str:
     return command.replace("\\", "\\\\").replace("%", "%%").replace('"', '\\"')
 
 
-def build_systemd_service(command: str = DEFAULT_COMMAND) -> str:
+def build_systemd_service(command: str = DEFAULT_COMMAND, workdir: str | None = None) -> str:
     wrapped = _systemd_escape(_wrap_command(command))
+    # Without WorkingDirectory the service starts in $HOME and the headless
+    # editor cannot find the newsroom (specs/, collectors/, editions/).
+    workdir_line = f"WorkingDirectory={workdir}\n" if workdir else ""
     return (
         "[Unit]\n"
         "Description=Morning Paper daily edition\n"
         "\n"
         "[Service]\n"
         "Type=oneshot\n"
+        f"{workdir_line}"
         f'ExecStart=/bin/sh -c "{wrapped}"\n'
         f"StandardOutput=append:{log_path()}\n"
         f"StandardError=append:{log_path()}\n"
@@ -239,8 +252,17 @@ def build_systemd_timer(time_str: str = DEFAULT_TIME) -> str:
     )
 
 
-def build_cron_line(time_str: str = DEFAULT_TIME, command: str = DEFAULT_COMMAND) -> str:
+def build_cron_line(
+    time_str: str = DEFAULT_TIME,
+    command: str = DEFAULT_COMMAND,
+    workdir: str | None = None,
+) -> str:
     hour, minute = parse_time(time_str)
+    if workdir:
+        # cron starts jobs in $HOME, where the newsroom is not; cd first. The
+        # path rides single-quoted with the same '\'' escape the outer wrapper
+        # uses below, so a workdir containing single quotes survives both layers.
+        command = "cd '{}' && {}".format(workdir.replace("'", "'\\''"), command)
     # The wrapped command rides inside single quotes, so embedded single
     # quotes (the date format, "today's") become '\'' — and cron turns an
     # unescaped % into a newline inside the command field, hence \%.
@@ -309,14 +331,14 @@ def _launchctl_state() -> dict | None:
 # --- install / uninstall / status ---
 
 
-def _install_darwin(time_str: str, command: str) -> tuple[dict, int]:
+def _install_darwin(time_str: str, command: str, workdir: str | None = None) -> tuple[dict, int]:
     plist_file = launchd_plist_path()
     plist_file.parent.mkdir(parents=True, exist_ok=True)
     log_path().parent.mkdir(parents=True, exist_ok=True)
     if plist_file.exists():
         # Re-install: unload the old job first so the new time/command takes.
         _bootout_quietly()
-    plist_file.write_bytes(plistlib.dumps(build_launchd_plist(time_str, command)))
+    plist_file.write_bytes(plistlib.dumps(build_launchd_plist(time_str, command, workdir)))
     loaded = False
     note = None
     bootstrap = _run(["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_file)])
@@ -349,11 +371,11 @@ def _bootout_quietly() -> None:
         _run(["launchctl", "unload", str(launchd_plist_path())])
 
 
-def _install_systemd(time_str: str, command: str) -> tuple[dict, int]:
+def _install_systemd(time_str: str, command: str, workdir: str | None = None) -> tuple[dict, int]:
     unit_dir = systemd_unit_dir()
     unit_dir.mkdir(parents=True, exist_ok=True)
     log_path().parent.mkdir(parents=True, exist_ok=True)
-    systemd_service_path().write_text(build_systemd_service(command), encoding="utf-8")
+    systemd_service_path().write_text(build_systemd_service(command, workdir), encoding="utf-8")
     systemd_timer_path().write_text(build_systemd_timer(time_str), encoding="utf-8")
     _run(["systemctl", "--user", "daemon-reload"])
     enable = _run(["systemctl", "--user", "enable", "--now", f"{SYSTEMD_UNIT}.timer"])
@@ -373,12 +395,12 @@ def _read_crontab() -> str:
     return listing.stdout if listing.returncode == 0 else ""
 
 
-def _install_cron(time_str: str, command: str) -> tuple[dict, int]:
+def _install_cron(time_str: str, command: str, workdir: str | None = None) -> tuple[dict, int]:
     log_path().parent.mkdir(parents=True, exist_ok=True)
     kept = [
         line for line in _read_crontab().splitlines() if CRON_MARKER not in line
     ]
-    kept.append(build_cron_line(time_str, command))
+    kept.append(build_cron_line(time_str, command, workdir))
     write = _run(["crontab", "-"], input_text="\n".join(kept) + "\n")
     payload = {
         "installed": write.returncode == 0,
@@ -397,11 +419,17 @@ def install_routine(
     time_str: str = DEFAULT_TIME,
     command: str | None = None,
     platform: str | None = None,
+    workdir: str | None = None,
 ) -> tuple[dict, int]:
     hour, minute = parse_time(time_str)  # validates; raises ValueError
     time_str = f"{hour:02d}:{minute:02d}"
     explicit_command = command is not None
     command = command or DEFAULT_COMMAND
+    # The scheduled job inherits no shell cwd, so it must be pinned to a
+    # directory at install time. The contract: the user installs from their
+    # newsroom — capture that directory now so the headless edition run can
+    # find specs/, collectors/, and editions/ every morning.
+    workdir = os.path.abspath(workdir) if workdir else os.getcwd()
     if not explicit_command and _resolve_claude() is None:
         # The default job is headless Claude; installing it without the binary
         # would just fail silently every morning. Refuse, and hand the user
@@ -424,11 +452,11 @@ def install_routine(
         )
     scheduler = detect_scheduler(platform)
     if scheduler == "launchd":
-        payload, code = _install_darwin(time_str, command)
+        payload, code = _install_darwin(time_str, command, workdir)
     elif scheduler == "systemd":
-        payload, code = _install_systemd(time_str, command)
+        payload, code = _install_systemd(time_str, command, workdir)
     elif scheduler == "cron":
-        payload, code = _install_cron(time_str, command)
+        payload, code = _install_cron(time_str, command, workdir)
     else:
         return (
             {
@@ -446,6 +474,7 @@ def install_routine(
                 "semantics": schedule_semantics(scheduler, time_str),
             },
             "command": command,
+            "workdir": workdir,
             "log": str(log_path()),
         }
     )
@@ -465,12 +494,12 @@ def _installed_scheduler() -> str | None:
     return None
 
 
-def _schedule_from_launchd() -> tuple[str | None, str | None]:
+def _schedule_from_launchd() -> tuple[str | None, str | None, str | None]:
     try:
         with launchd_plist_path().open("rb") as handle:
             data = plistlib.load(handle)
     except Exception:
-        return None, None
+        return None, None, None
     interval = data.get("StartCalendarInterval") or {}
     time_str = None
     if isinstance(interval, dict) and "Hour" in interval and "Minute" in interval:
@@ -479,7 +508,8 @@ def _schedule_from_launchd() -> tuple[str | None, str | None]:
     args = data.get("ProgramArguments") or []
     if len(args) == 3 and args[0] == "/bin/sh":
         command = _unwrap_command(args[2]) or args[2]
-    return time_str, command
+    workdir = data.get("WorkingDirectory")
+    return time_str, command, workdir if isinstance(workdir, str) else None
 
 
 def _schedule_from_systemd() -> tuple[str | None, str | None]:
@@ -527,8 +557,9 @@ def routine_status() -> dict:
             "log": str(log_path()),
             "hint": "schedule the daily edition with `morning-paper routine install`",
         }
+    workdir = None
     if scheduler == "launchd":
-        time_str, command = _schedule_from_launchd()
+        time_str, command, workdir = _schedule_from_launchd()
     elif scheduler == "systemd":
         time_str, command = _schedule_from_systemd()
     else:
@@ -545,6 +576,8 @@ def routine_status() -> dict:
         "next_fire": next_fire(time_str) if time_str else None,
         "log": str(log_path()),
     }
+    if workdir:
+        payload["workdir"] = workdir
     if scheduler == "launchd":
         state = _launchctl_state()
         if state:
@@ -578,15 +611,18 @@ def routine_doctor_summary() -> dict:
     """File-checks only (no subprocess) so doctor stays fast and offline."""
     scheduler = None
     time_str = None
+    workdir = None
     if launchd_plist_path().is_file():
         scheduler = "launchd"
-        time_str, _ = _schedule_from_launchd()
+        time_str, _, workdir = _schedule_from_launchd()
     elif systemd_timer_path().is_file():
         scheduler = "systemd"
         time_str, _ = _schedule_from_systemd()
     summary: dict[str, object] = {"installed": scheduler is not None, "scheduler": scheduler}
     if time_str:
         summary["time"] = time_str
+    if workdir:
+        summary["workdir"] = workdir
     return summary
 
 
@@ -596,7 +632,9 @@ def routine_doctor_summary() -> dict:
 def routine_command(args: list[str]) -> int:
     usage = (
         "usage: morning-paper routine <install|status|uninstall> "
-        "[--time HH:MM] [--command CMD]"
+        "[--time HH:MM] [--command CMD] [--workdir PATH]\n"
+        "  --workdir PATH  newsroom directory the daily run starts in "
+        "(default: current directory)"
     )
     if not args or args[0] in {"-h", "--help"}:
         print(usage)
@@ -604,6 +642,7 @@ def routine_command(args: list[str]) -> int:
     action, rest = args[0], args[1:]
     time_str = DEFAULT_TIME
     command: str | None = None
+    workdir: str | None = None
     index = 0
     while index < len(rest):
         arg = rest[index]
@@ -618,11 +657,23 @@ def routine_command(args: list[str]) -> int:
             command = rest[index + 1]
             index += 2
             continue
+        if arg == "--workdir" and index + 1 < len(rest):
+            workdir = rest[index + 1]
+            index += 2
+            continue
         print(f"unknown routine argument: {arg}", file=sys.stderr)
         return 2
     if action == "install":
+        if workdir is not None and not os.path.isdir(workdir):
+            print(
+                f"invalid --workdir {workdir!r}: not an existing directory — pass the "
+                "newsroom directory the daily run should start in "
+                "(default: current directory)",
+                file=sys.stderr,
+            )
+            return 2
         try:
-            payload, code = install_routine(time_str, command)
+            payload, code = install_routine(time_str, command, workdir=workdir)
         except ValueError as exc:
             print(str(exc), file=sys.stderr)
             return 2

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -113,6 +113,113 @@ class UnitGenerationTests(RoutineHomeTestCase):
         self.assertIn("'\\''", line)  # single quotes inside the single-quoted command
 
 
+class WorkdirTests(RoutineHomeTestCase):
+    """The scheduled run must start in the newsroom, not wherever the
+    scheduler feels like ($HOME for launchd/cron) — otherwise the headless
+    editor cannot find specs/, collectors/, editions/."""
+
+    def test_plist_contains_workdir_when_passed(self) -> None:
+        data = routine.build_launchd_plist(workdir="/srv/newsroom")
+        self.assertEqual(data["WorkingDirectory"], "/srv/newsroom")
+
+    def test_plist_omits_workdir_when_none(self) -> None:
+        self.assertNotIn("WorkingDirectory", routine.build_launchd_plist())
+
+    def test_systemd_service_workdir_line(self) -> None:
+        service = routine.build_systemd_service("echo hi", workdir="/srv/newsroom")
+        self.assertIn("WorkingDirectory=/srv/newsroom\n", service)
+        # the directive belongs to [Service], ahead of ExecStart
+        self.assertLess(service.index("[Service]"), service.index("WorkingDirectory="))
+        self.assertLess(service.index("WorkingDirectory="), service.index("ExecStart="))
+        self.assertNotIn("WorkingDirectory", routine.build_systemd_service("echo hi"))
+
+    def test_cron_line_cds_into_workdir(self) -> None:
+        line = routine.build_cron_line("05:00", "echo hi", workdir="/srv/newsroom")
+        # the path is single-quoted inside the single-quoted sh -c command,
+        # so its quotes arrive pre-escaped with the same '\'' idiom
+        self.assertIn("cd '\\''/srv/newsroom'\\'' && echo hi", line)
+        self.assertNotIn("cd ", routine.build_cron_line("05:00", "echo hi"))
+
+    def test_cron_workdir_single_quote_survives_shell(self) -> None:
+        workdir = self.home / "it's the newsroom"
+        workdir.mkdir()
+        line = routine.build_cron_line("05:00", "pwd", workdir=str(workdir))
+        # cron hands the command field to /bin/sh after unescaping \% -> %
+        field = " ".join(line.split()[5:])
+        field = field[: field.rindex(">>")].replace(r"\%", "%")
+        proc = subprocess.run(["/bin/sh", "-c", field], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn(str(workdir), proc.stdout)
+
+    def test_install_defaults_workdir_to_cwd(self) -> None:
+        # the contract: the user installs from their newsroom
+        fake = FakeRun()
+        newsroom = self.home / "newsroom"
+        newsroom.mkdir()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(
+            routine, "_resolve_claude", return_value="/usr/local/bin/claude"
+        ), patch.object(routine.os, "getcwd", return_value=str(newsroom)):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                rc = cli.main(["routine", "install"])
+        self.assertEqual(rc, 0)
+        payload = json.loads(stdout.getvalue())
+        self.assertEqual(payload["workdir"], str(newsroom))
+        with routine.launchd_plist_path().open("rb") as handle:
+            data = plistlib.load(handle)
+        self.assertEqual(data["WorkingDirectory"], str(newsroom))
+
+    def test_install_systemd_writes_workdir(self) -> None:
+        fake = FakeRun()
+        newsroom = self.home / "newsroom"
+        newsroom.mkdir()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="linux"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/bin/claude"), patch.object(
+            routine, "_tool_exists", lambda name: name == "systemctl"
+        ), patch.object(routine.os, "getcwd", return_value=str(newsroom)):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                rc = cli.main(["routine", "install"])
+        self.assertEqual(rc, 0)
+        service = routine.systemd_service_path().read_text(encoding="utf-8")
+        self.assertIn(f"WorkingDirectory={newsroom}\n", service)
+
+    def test_install_workdir_override_and_status_surfaces_it(self) -> None:
+        fake = FakeRun()
+        newsroom = self.home / "the newsroom"
+        newsroom.mkdir()
+        with patch.object(routine, "_run", fake), patch.object(
+            routine, "_current_platform", return_value="darwin"
+        ), patch.object(routine, "_resolve_claude", return_value="/usr/local/bin/claude"):
+            stdout = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(io.StringIO()):
+                rc = cli.main(["routine", "install", "--workdir", str(newsroom)])
+        self.assertEqual(rc, 0)
+        self.assertEqual(json.loads(stdout.getvalue())["workdir"], str(newsroom))
+        with patch.object(routine, "_run", FakeRun()), patch.object(
+            routine, "_tool_exists", lambda name: False
+        ):
+            status_out = io.StringIO()
+            with redirect_stdout(status_out):
+                cli.main(["routine", "status"])
+        self.assertEqual(json.loads(status_out.getvalue())["workdir"], str(newsroom))
+
+    def test_install_workdir_must_be_a_directory(self) -> None:
+        fake = FakeRun()
+        missing = self.home / "nope"
+        with patch.object(routine, "_run", fake):
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                rc = cli.main(["routine", "install", "--workdir", str(missing)])
+        self.assertEqual(rc, 2)
+        self.assertIn("not an existing directory", stderr.getvalue())
+        self.assertEqual(fake.calls, [])
+        self.assertFalse(routine.launchd_plist_path().exists())
+
+
 class InstallDarwinTests(RoutineHomeTestCase):
     def _install(self, argv: list[str], fake: FakeRun):
         with patch.object(routine, "_run", fake), patch.object(
@@ -402,6 +509,8 @@ class DoctorRoutineTests(RoutineHomeTestCase):
         self.assertTrue(payload["routine"]["installed"])
         self.assertEqual(payload["routine"]["scheduler"], "launchd")
         self.assertEqual(payload["routine"]["time"], "06:00")
+        # install ran with no --workdir, so the captured cwd is in the plist
+        self.assertEqual(payload["routine"]["workdir"], os.getcwd())
 
     def test_doctor_human_output_mentions_routine(self) -> None:
         with patch.object(routine, "_tool_exists", lambda name: False):


### PR DESCRIPTION
## The bug (P0)

`routine install` wrote scheduler jobs with **no working directory**. launchd, systemd, and cron all start jobs somewhere generic — `$HOME`, effectively — so the headless `claude -p` edition run woke up every morning in a directory with no `specs/`, no `collectors/`, no `editions/`. The editor composed blind. Every routine user is affected; the failure is silent because the run itself exits fine — it just can't see the newsroom.

## The fix

- `install_routine` captures the directory you install from (the contract: you install from your newsroom) and pins the job to it. `--workdir PATH` overrides; validated as an existing directory with a clear error otherwise.
- launchd: `WorkingDirectory` plist key. systemd: `WorkingDirectory=` under `[Service]`. cron: a quote-safe `cd '<dir>' &&` inside the existing `sh -c` wrapper (single quotes in the path survive both quoting layers — there's a shell round-trip test for it).
- The install JSON reports the resolved `workdir`; `routine status` and `doctor` surface it from the launchd plist, where reading it is free.
- Edition skill, "Read the newsroom" hardened: when present, the editor also reads `memory/reads-ledger.md` (never reprint; append on ship), the latest `editions/<date>/operator-answers.md` (honor exactly), and checks `inbox/scans/` for untriaged captures.
- CHANGELOG + version bump to 0.5.2, with the upgrade note: existing installs should re-run `morning-paper routine install` from the newsroom.

## Tests

10 new/extended tests: plist key present/absent, systemd line placement, cron `cd` + single-quote shell round-trip, default-resolves-to-cwd (launchd + systemd), `--workdir` override + status surfacing, invalid-path rejection, doctor workdir report. Full suite: 117 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)