### PR TITLE
Scrub real PII + ban Fable + source-hygiene docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Set up with AI (recommended)
 
-Open your strongest model — Claude Fable with the 1M context works great — and paste this:
+Open your strongest model — Claude Opus 4.8 with the 1M context works great — and paste this:
 
 ```text
 I want a Morning Paper: an open-source personal newspaper my agent composes
@@ -197,6 +197,11 @@ can run anywhere — the paper still lands on your desk.
 | RSS feeds | No | Included |
 | Article URLs | No | Included via `print` / `stage` |
 
+Everything else — a subreddit digest, your GitHub activity, an X radar, a
+weekly research roundup — is a *collector*: a small script you run before
+composing that stages markdown into the queue. See
+[docs/collectors.md](docs/collectors.md) for the contract.
+
 ## Four styles, two palettes
 
 `morning-paper styles` lists them all — a family of four, each named for the
@@ -261,6 +266,8 @@ shipping something worse. The paper never lies to you about what it knows.
 
 - [docs/composing.md](docs/composing.md) — the composition contract for agents:
   document structure, class vocabulary, chart directives
+- [docs/collectors.md](docs/collectors.md) — bring your own sources: how to add
+  anything beyond the built-in HN + RSS by staging into the queue
 - [docs/inbox.md](docs/inbox.md) — the contributor inbox: let people you
   trust email articles into tomorrow's paper (Gmail/iCloud app-password setup)
 - [ROADMAP.md](ROADMAP.md) — what shipped, what's next

--- a/docs/architecture-decisions.md
+++ b/docs/architecture-decisions.md
@@ -15,13 +15,18 @@ Reason:
 - `Morning Paper` is the public engine.
 - Private deployments extend it for specific operators.
 - Public repo owns:
-  - collectors
+  - the built-in HN + RSS build path
+  - the generic stage/inbox/build/render contract
   - normalized models
   - CLI
   - renderer implementations
   - tests
   - example configs
-- Private deployments own their own scheduling, credentials, delivery, and operator-specific configuration.
+- Collectors are NOT in the engine. The engine ships HN + RSS and the
+  stage/inbox contract any script can write to; every other source is a
+  collector the operator authors and runs in their own private newsroom
+  (see [docs/collectors.md](collectors.md)).
+- Private deployments own their own collectors, scheduling, credentials, delivery, and operator-specific configuration.
 
 Reason:
 - The OSS package must stand on its own and remain portable.
@@ -350,7 +355,7 @@ Path:
 
 Purpose:
 - make the CLI discoverable in Claude Code style runtimes
-- provide a stable command contract for Hermes/OpenClaw-style agent environments
+- provide a stable command contract for always-on agent runtimes
 - keep runtime integration thin: skills call the CLI, they do not reimplement the pipeline
 
 ## 17. Visual Snapshot Testing

--- a/docs/collectors.md
+++ b/docs/collectors.md
@@ -1,0 +1,163 @@
+# Collectors — bring your own sources
+
+Morning Paper ships two built-in sources: **Hacker News** and **RSS feeds**.
+`morning-paper build` reads those, lays out an edition, and prints it with zero
+configuration. That is the default, and for many readers it is the whole
+product.
+
+A **collector** is how you add anything else — a subreddit digest, your GitHub
+activity, an X/Twitter radar, a weekly research roundup, your bank's RSS-less
+statements page, whatever earns a place on your desk. This page is the contract
+a collector has to honor. Write to it and your source flows into the same
+edition as HN and RSS, through the same renderer, under the same page budget.
+
+## What a collector is
+
+A collector is **any script you run before you compose**. It can be a Python
+file, a shell pipeline, a Claude Code skill, a cron job — the engine does not
+care what language it is or how it runs. Its only job is to turn a source into
+**staged material**: markdown the editor will read when it composes today's
+paper.
+
+Collectors are yours. They live in your private newsroom repo (the `setup`
+skill scaffolds a `collectors/` directory for exactly this), never in the
+public engine. The engine gives you a stable place to drop their output and a
+budget-aware queue to read it back — nothing about your sources, credentials,
+or scraping logic ever touches the engine repo.
+
+## Where a collector writes (the staging contract)
+
+Staged material lives in a date-keyed staging directory under the output
+directory (`outputs.directory` in your config, default
+`~/.local/share/morning-paper`):
+
+```text
+<outputs.directory>/staging/<YYYY-MM-DD>/queue.json     # the manifest
+<outputs.directory>/staging/<YYYY-MM-DD>/<slug>.md      # one file per item
+```
+
+The date is **the edition the item is for**. Material collected during the day
+is for *tomorrow's* paper, so most collectors target tomorrow's date.
+
+You have two ways to write into it.
+
+### The easy way: `morning-paper stage` (recommended)
+
+Let the engine own the file layout, slug collisions, the page estimate, and the
+honesty flags. Your collector just calls the CLI once per item:
+
+```bash
+# A URL — fetched and extracted exactly like `print`, with the same
+# truncation / extractor-fallback honesty notes recorded in the queue:
+morning-paper stage "https://example.com/some-article" --title "Optional title"
+
+# A local markdown file your collector already produced:
+morning-paper stage ~/tmp/reddit-digest.md --title "r/selfhosted, this week"
+
+# Target a specific edition date (defaults to tomorrow):
+morning-paper stage report.md --date 2026-06-14
+```
+
+Each call prints a JSON receipt — slug, word count, estimated pages, and any
+honesty flags — so an agent collector can report "that adds ~3 pages; it's in
+the queue." This is the same path the contributor inbox uses, so a staged item
+is identical no matter how it arrived.
+
+### The direct way: write the files yourself
+
+If you would rather not shell out per item (a high-volume collector, an offline
+build), write the staging files directly. Append one entry per item to
+`queue.json` and drop a matching `<slug>.md`. A queue entry looks like:
+
+```json
+{
+  "slug": "r-selfhosted-this-week",
+  "kind": "file",
+  "source": "https://reddit.com/r/selfhosted/top",
+  "title": "r/selfhosted, this week",
+  "words": 640,
+  "est_pages": 2,
+  "staged_at": "2026-06-13T18:04:00-04:00",
+  "truncated": false,
+  "warning": "",
+  "extractor_note": "",
+  "contributor": ""
+}
+```
+
+Honesty is part of the contract, not an afterthought. If your collector only
+captured a partial source, set `truncated: true` and put a plain-language
+reason in `warning` ("paywall cut the body after 3 paragraphs"). If the content
+left the machine through a third-party service, say so in `extractor_note`. The
+editor surfaces these notes rather than printing a clipped article as if it were
+whole. `slug` must be unique within the day; `est_pages` is your honest page
+estimate (the CLI computes it from a real layout pass — if you are writing the
+file by hand, a words-per-page heuristic of roughly 550 words/page is the
+engine's own fallback).
+
+`kind` is free-form metadata: `url`, `file`, or `note` are the conventions the
+built-in paths use.
+
+## Reading the queue back
+
+Whatever wrote it, the editor reads the same queue:
+
+```bash
+morning-paper queue                  # what's staged vs the page budget (JSON)
+morning-paper queue --date 2026-06-14
+```
+
+`queue` reports the item list, total estimated pages, your `page_budget`, and
+how many pages remain — so the compose step knows what fits before it lays a
+single column. Anything in the queue was put there on purpose (by you, a
+collector, or a trusted contributor) and is treated as belonging in the paper.
+
+## Output formats
+
+A staged `.md` file is **markdown**, and it may contain the same raw HTML and
+chart directives (`mp-bars`, `mp-spark`, `mp-stats`) the composer uses — see
+[docs/composing.md](composing.md) for the class vocabulary. A collector can
+either:
+
+- hand the engine a **URL** and let `stage` fetch and render it, or
+- produce its own **markdown** (already-formatted prose, tables, charts) and
+  stage that.
+
+JSON only appears in `queue.json` (the manifest) — the staged *content* is
+always markdown, because markdown is the durable intermediate the renderer
+consumes.
+
+## Collectors run at compose time, outside the page budget
+
+A collector runs **before** composition, during the edition skill's "Collect"
+step. Running a collector does not, by itself, cost pages — it fills the queue.
+The page budget is enforced later, when the editor composes: it reads the queue
+with `morning-paper queue`, weighs everything staged against `page_budget`, and
+cuts the weakest material to fit. So a collector can stage generously; the
+editor decides what survives to print. A collector that stages ten pages into a
+twelve-page budget has not broken anything — it has given the editor choices.
+
+## The shape of a minimal collector
+
+```bash
+#!/usr/bin/env bash
+# collectors/github-shipped.sh — a "shipped while you slept" section.
+set -euo pipefail
+
+tomorrow="$(date -v+1d +%F 2>/dev/null || date -d tomorrow +%F)"
+
+gh search prs --author=@me --merged --merged-at=">$(date -v-1d +%F)" \
+  --json title,url,repository \
+  | jq -r '.[] | "- [\(.title)](\(.url)) — \(.repository.name)"' \
+  > /tmp/shipped.md
+
+# Only stage if there's anything to show — honest empty beats a fake section.
+if [ -s /tmp/shipped.md ]; then
+  { echo "# Shipped while you slept"; echo; cat /tmp/shipped.md; } \
+    | morning-paper stage /dev/stdin --title "Shipped" --date "$tomorrow" \
+    || morning-paper stage <(cat /tmp/shipped.md) --title "Shipped" --date "$tomorrow"
+fi
+```
+
+That is the whole idea: a script that produces markdown and stages it. The
+engine prints HN and RSS for free; collectors are how the paper becomes yours.

--- a/docs/composing.md
+++ b/docs/composing.md
@@ -175,7 +175,7 @@ A typical cover, straight from the pack's reference sample:
 <div class="z2-plate">
   <div><span class="z2-strip">WAKE THE</span></div>
   <div><span class="z2-strip alt">PRINTER!</span></div>
-  <div class="z2-plate-sub">the thoth LaserJet revival guide</div>
+  <div class="z2-plate-sub">the neighborhood press revival guide</div>
 </div>
 <div class="z2-plate-dots"></div>
 <div class="z2-dots-exit"></div>

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -44,14 +44,23 @@ Ask in 2-3 messages, not twenty. Capture:
 
 Write their answers into `~/.config/morning-paper/config.yaml`.
 
-## 3. Optional unlocks (state the leverage, let them skip)
+## 3. Optional unlocks (collector recipes they write, not engine features)
 
-- **Apify key** (`APIFY_TOKEN`): X/Twitter radar via tweet-scraper actors,
-  about $0.02/day at 40 tweets. Worth it if their work has a market lane.
-- **last30days plugin**: Reddit/HN/Polymarket deep research for a weekly
-  trends page.
-- **gh CLI**: a "shipped while you slept" section from their repos.
-Each missing unlock = a section that prints "not configured", never fake data.
+The engine ships exactly two built-in sources — Hacker News and RSS — plus the
+generic stage/inbox contract any script can write to. Everything below is a
+**collector**: a small script the operator (or their agent) authors and runs at
+compose time, dropping markdown into the staging queue. None of these ship in
+the engine; they are recipes to build in the newsroom's `collectors/`. See
+[docs/collectors.md](../../docs/collectors.md) for the contract.
+
+- **Apify** (`APIFY_TOKEN`): a collector that pulls an X/Twitter radar via
+  tweet-scraper actors, about $0.02/day at 40 tweets. Worth it if their work
+  has a market lane.
+- **last30days**: a collector wrapping the Reddit/HN/Polymarket research plugin
+  for a weekly trends page.
+- **gh CLI**: a collector that builds a "shipped while you slept" section from
+  their repos.
+Each collector they skip = a section that prints "not configured", never fake data.
 
 ## 4. The masthead (the contributor inbox)
 

--- a/skills/writing/SKILL.md
+++ b/skills/writing/SKILL.md
@@ -68,9 +68,10 @@ filler; *one of the most* as an opener; *worth while* as vague approval;
 
 What readers now flag as machine prose, deadliest first. Vocabulary tells
 ("delve," "tapestry," "testament") have largely faded from current models;
-the structural habits below survive every generation so far, Fable 5
-included — its launch reviews describe the default voice as fluent, tidy,
-editorially polished, and generic. This pass exists to cut exactly that.
+the structural habits below survive every model generation so far — current
+frontier models (Claude Opus 4.8, Codex 5.5) included still default to a voice
+reviewers describe as fluent, tidy, editorially polished, and generic. This
+pass exists to cut exactly that.
 
 1. **Uniform cadence.** Sentences of 18–24 words, one after another, page
    after page — the single most durable tell. Fix with sentence music
@@ -106,7 +107,7 @@ editorially polished, and generic. This pass exists to cut exactly that.
    Ration to roughly one dash construction per paragraph. Commas, colons,
    and periods do the rest.
 10. **Abstraction where a detail exists.** *Before:* "a strong signal from
-    the funnel." *After:* "brian@lakeerieroof.com, a roofing-company
+    the funnel." *After:* "dispatch@havenroof.example, a roofing-company
     domain." The concrete noun is the credibility.
 11. **Symmetry everywhere.** Every list item the same length, every
     paragraph the same three-sentence arc, every section the same close.

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -171,7 +171,7 @@ _ZINE_V2_SAMPLE = """\
 
 <div class="z2-step"><strong>SSH in</strong> from any machine on the tailnet:</div>
 
-<div class="z2-cmd">ssh thoth</div>
+<div class="z2-cmd">ssh homelab</div>
 
 <div class="z2-step"><strong>Cancel everything stale:</strong></div>
 


### PR DESCRIPTION
All mechanical, audit-specified cleanups to the public engine. No version bump, no tag, no release.

## P0 — real PII removal
- `skills/writing/SKILL.md` kill-list item #10 used a **real lead email** (`brian@lakeerieroof.com`) as a "concrete beats vague" example. Replaced with a clearly-fictional `.example` address (`dispatch@havenroof.example`) that keeps the teaching point — a specific concrete noun reads as credibility.
- Swept the entire working tree for other real PII (`git grep` over emails + person/company/private terms). Every remaining email is an obvious placeholder (`you@gmail.com`, `someone-you-trust@example.com`, `stranger@example.com`, test fixtures) and was left as-is. `Devon Meadows` / `skool.com/main` are the owner's already-published terms (LICENSE, package author, community link) and were left.

## Fable scrub (recommendation surfaces only)
- `README.md` setup prompt: "Claude Fable" → "Claude Opus 4.8".
- `skills/writing/SKILL.md`: the AI-tells preamble now names approved models — "current frontier models (Claude Opus 4.8, Codex 5.5)" — instead of Fable 5. Surrounding prose preserved.

## Source-hygiene cleanups
- **False collectors line** in `docs/architecture-decisions.md` §2: the engine does not own "collectors". Rewritten so the public repo owns the built-in HN + RSS path and the generic stage/inbox/build/render contract; collectors are operator-authored and live in the private newsroom.
- Dropped `Hermes/OpenClaw` brand names in §16 → "always-on agent runtimes".
- Genericized the private host name `thoth` in the zine samples (`docs/composing.md`, `tests/test_styles.py`); the test sample input was updated and the render smoke test still passes.
- Relabeled `skills/setup/SKILL.md` §3 (Apify / last30days / gh) as **collector recipes the operator writes**, not built-in engine features.

## New doc
- `docs/collectors.md` — the missing "bring your own sources" contract: what a collector is, where it writes (the `<outputs.directory>/staging/<date>/` queue + honesty flags), output formats, that collectors run at compose time outside the page budget, and that built-in `morning-paper build` (HN+RSS) is the zero-config default. Linked from `README.md` (near Sources + Docs) and `skills/setup/SKILL.md` §3.

## Out of scope
History-level private-content remediation (git history rewrite / tag handling) is **tracked separately and is NOT part of this PR**.

## Tests
`python -m pytest tests/` — 117 passed, 5 skipped (skips need the WeasyPrint pretty stack). With the pretty stack installed, both zine render smoke tests (which consume the edited sample) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)