### PR TITLE
0.6.1 — scope review headline length checks to true headlines

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "morning-paper",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Your personal newsroom: a daily printed paper composed by your agent from your sources, with preferences you own as files.",
   "author": { "name": "Devon Meadows", "url": "https://github.com/dmthepm" },
   "homepage": "https://github.com/dmthepm/morning-paper",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-22
+
+### Fixed
+- **`review` headline length checks no longer cry wolf on deck/department titles.** The `headline-line-count` and `headline-length` checks (shipped in 0.6.0) treated EVERY composed head the same — `.mg-title`, `.dept-title`, and `.oc-title` alike — and flagged each one that ran past the line/character budget. But `.dept-title` is a broadsheet DEPARTMENT title: a multi-sentence summary that the renderer emits for every read/department/staged item, long BY DESIGN. The result was ~90% false positives on a normal edition (a known-good delivered edition trips them too), which trained the editor to ignore the one QC gate the `edition` skill says to act on. The two LENGTH checks now flag only TRUE headlines — the lead/front head (`.mg-title`), a printed article's headline (`.article-title`), the field-card title (`.oc-title`), and markdown `#`/`##` heads in the simpler packs — and EXEMPT deck/department/section-label elements (`.dept-title`, `.mg-dek`, kickers). The class → role map is explicit and documented in `reviewers.py` (`_TRUE_HEAD_CLASSES` / `_DECK_HEAD_CLASSES`, `Headline.role`). The other headline checks are unchanged: `headline-verb-presence`, `hed-dek-redundancy`, and `duplicate-headline` still read every head regardless of role, so a label-style department title with no verb still flags. A genuinely-overlong real headline still flags exactly as before — only the deck false positives drop out
+- Tests: a long `.dept-title` deck does NOT trip `headline-line-count` or `headline-length`; a real `.mg-title` headline over the line/char limit still flags (both the line-count flag and the length nudge); the existing length-check fixtures were retargeted from `.dept-title` (now a deck) to `.mg-title` (a true headline)
+
 ## [0.6.0] - 2026-06-21
 
 ### Added

--- a/docs/composing.md
+++ b/docs/composing.md
@@ -82,8 +82,8 @@ The eight checks, all text-only (they run even on a fallback-only install):
 
 | Check | Severity | Flags |
 |---|---|---|
-| `headline-line-count` | flag | a head estimated to wrap 3+ lines at the pack's measure |
-| `headline-length` | nudge | a head over ~60 characters |
+| `headline-line-count` | flag | a TRUE headline estimated to wrap 3+ lines at the pack's measure |
+| `headline-length` | nudge | a TRUE headline over ~60 characters |
 | `headline-verb-presence` | flag | a label head with no finite verb |
 | `hed-dek-redundancy` | nudge | a deck that echoes ≥50% of the head's words |
 | `section-balance` | nudge | a section >2.5× the median, or one lonely item next to fat ones |
@@ -95,6 +95,16 @@ The eight checks, all text-only (they run even on a fallback-only install):
 prevents (orphan/widow *lines*, stranded heads). It catches the residue CSS
 cannot fix: a head that still wraps because the *words* are long, a starved or
 dead section, a stale or duplicate story.
+
+The two LENGTH checks (`headline-line-count`, `headline-length`) measure only
+**true headlines** — the lead/front head (`.mg-title`), a printed article's
+headline (`.article-title`), the field-card title (`.oc-title`), and markdown
+`#`/`##` heads in the simpler packs. They **exempt** deck/department/section
+labels (`.dept-title`, `.mg-dek`, kickers), which are multi-sentence summaries
+long by design — flagging them was the 0.6.0 false positive. The other
+headline checks (`headline-verb-presence`, `hed-dek-redundancy`,
+`duplicate-headline`) still read every head, so a label-style department title
+with no verb still flags.
 
 A newsroom's `preferences/checks.yaml` (when present) tunes the checks — the
 file is read automatically, never written by `review`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "morning-paper"
-version = "0.6.0"
+version = "0.6.1"
 description = "Build a personalized daily newspaper as a print-ready PDF."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/morning_paper/__init__.py
+++ b/src/morning_paper/__init__.py
@@ -1,3 +1,3 @@
 __all__ = ["__version__"]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/morning_paper/reviewers.py
+++ b/src/morning_paper/reviewers.py
@@ -84,6 +84,13 @@ class Headline:
     kind: str  # "headline"
     section: str
     deck: str = ""
+    # role tells a TRUE headline (the lead/front head + article heads) apart
+    # from a DECK / DEPARTMENT / SECTION LABEL that is long by design. The two
+    # length checks (line-count, length) flag only true headlines; decks and
+    # labels are intentionally multi-sentence summaries and must not trip them.
+    # See HEADLINE_ROLE_* below for the class → role mapping. Verb-presence and
+    # hed-dek-redundancy still read every head regardless of role.
+    role: str = "headline"  # "headline" | "deck"
 
 
 @dataclass(slots=True)
@@ -108,10 +115,40 @@ class ParsedEdition:
 # ---------------------------------------------------------------------------
 # Artifact resolution + parsing
 # ---------------------------------------------------------------------------
-# A composed head wears one of these class names (broadsheet .mg-title/
-# .dept-title, field-card .oc-title). Plain markdown headings are heads too.
+# Headline ROLE vocabulary — the explicit, maintainable map from a head's CSS
+# class to whether the LENGTH checks treat it as a real headline.
+#
+# TRUE HEADLINES (role "headline") — the lead/front head and per-article heads.
+# These carry the news in a tight line and SHOULD flag when they run long:
+#   .mg-title   broadsheet lead/front headline (demo.md: "The Lighthouse
+#               Keeper Wants a Quieter Lamp" — a real, tight hed)
+#   .article-title  a printed article's own headline (article_print.py)
+#   .oc-title   field-card main title (its pack's headline)
+#   plus markdown #/## headings, which double as the head in the simpler packs.
+#
+# DECKS / DEPARTMENT / SECTION LABELS (role "deck") — EXEMPT from the length
+# checks. These are multi-sentence summaries or department names that are long
+# BY DESIGN; flagging them is the 0.6.0 false positive that trained editors to
+# ignore the gate (dogfood 2026-06-21). They are still parsed so verb-presence,
+# hed-dek-redundancy, and duplicate-headline can read them — only the two
+# LENGTH checks skip them:
+#   .dept-title broadsheet DEPARTMENT title (15pt; the renderer emits it for
+#               every read/dept/staged item — a deck, not a one-line hed)
+#   .mg-dek     the deck (an explicit second-beat summary, always prose-length)
+#   .dept-kicker / .mg-kicker  section labels / kickers
+#
+# A composed head wears one of these class names; plain markdown headings are
+# heads too. The two regexes below split heads by role at parse time.
+_TRUE_HEAD_CLASSES = ("mg-title", "article-title", "oc-title")
+_DECK_HEAD_CLASSES = ("dept-title", "mg-dek")
 _HEAD_DIV_RE = re.compile(
-    r'<div[^>]*class="[^"]*\b(?:mg-title|dept-title|oc-title)\b[^"]*"[^>]*>(.*?)</div>',
+    r'<div[^>]*class="[^"]*\b(?:mg-title|article-title|oc-title)\b[^"]*"[^>]*>(.*?)</div>',
+    re.IGNORECASE | re.DOTALL,
+)
+# Deck/department heads: parsed (so the non-length checks see them) but tagged
+# role "deck" so the length checks skip them.
+_DECK_HEAD_DIV_RE = re.compile(
+    r'<div[^>]*class="[^"]*\b(?:dept-title)\b[^"]*"[^>]*>(.*?)</div>',
     re.IGNORECASE | re.DOTALL,
 )
 _DECK_DIV_RE = re.compile(
@@ -282,20 +319,36 @@ def parse_edition(artifacts: dict[str, Path]) -> ParsedEdition:
                     return d_text
             return ""
 
-        # headlines: head divs (.mg-title/.dept-title/.oc-title)
+        # TRUE headlines: lead/article head divs (.mg-title/.article-title/
+        # .oc-title). These flag when they run long.
         for m in _HEAD_DIV_RE.finditer(body):
             text = _strip_tags(m.group(1))
             if text:
                 headlines.append(
-                    Headline(text=text, kind="headline", section=_section_at(m.start()), deck=_deck_near(m.start()))
+                    Headline(
+                        text=text, kind="headline", section=_section_at(m.start()),
+                        deck=_deck_near(m.start()), role="headline",
+                    )
+                )
+        # DECK / DEPARTMENT heads: .dept-title — parsed so verb/redundancy/
+        # duplicate checks still read them, but tagged role "deck" so the two
+        # length checks skip them (they are long summaries by design).
+        for m in _DECK_HEAD_DIV_RE.finditer(body):
+            text = _strip_tags(m.group(1))
+            if text:
+                headlines.append(
+                    Headline(
+                        text=text, kind="headline", section=_section_at(m.start()),
+                        deck=_deck_near(m.start()), role="deck",
+                    )
                 )
         # headlines: markdown ## / # headings double as both section and head
-        # in the simpler packs (brief/zine). Treat them as headlines too.
+        # in the simpler packs (brief/zine). Treat them as true headlines.
         for m in re.finditer(r"^(#{1,2})\s+(.+)$", body, re.MULTILINE):
             text = m.group(2).strip()
             if text:
                 headlines.append(
-                    Headline(text=text, kind="headline", section=text, deck=_deck_near(m.start()))
+                    Headline(text=text, kind="headline", section=text, deck=_deck_near(m.start()), role="headline")
                 )
 
         sections = _section_word_counts(body, section_spans)
@@ -533,6 +586,10 @@ def check_headline_line_count(ed: ParsedEdition, prefs: Preferences) -> list[Fin
     strong_at = int(strong_at)
     out: list[Finding] = []
     for h in ed.headlines:
+        # only TRUE headlines wrap-flag; decks/department titles run long by
+        # design (dogfood 2026-06-21 — the 0.6.0 false positive).
+        if h.role != "headline":
+            continue
         lines = _estimate_lines(h.text, ed.style)
         if lines < warn_at:
             continue
@@ -557,6 +614,10 @@ def check_headline_length(ed: ParsedEdition, prefs: Preferences) -> list[Finding
     nudge_at = int(nudge_at)
     out: list[Finding] = []
     for h in ed.headlines:
+        # only TRUE headlines nudge on length; decks/department titles are
+        # intentionally long summaries (dogfood 2026-06-21).
+        if h.role != "headline":
+            continue
         if len(h.text) <= nudge_at:
             continue
         out.append(

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,8 +1,11 @@
-"""The `review` verb — editorial QC on a finished edition (0.6.0).
+"""The `review` verb — editorial QC on a finished edition (0.6.0, scoped 0.6.1).
 
 Phase 0 (the verb + report model + registry runner) and Phase 1 (the eight
 TEXT-only checks + checks.yaml reading). The checker never fails: exit 0 by
 default; --strict makes a flag (and only a flag) exit 1.
+
+0.6.1 scopes the two LENGTH checks (line-count, length) to TRUE headlines:
+deck/department titles (.dept-title) are long by design and are exempt.
 """
 
 from __future__ import annotations
@@ -101,8 +104,8 @@ class ReportModelTest(unittest.TestCase):
 
     def test_finding_object_carries_location_issue_why(self) -> None:
         report = _review(
-            '<div class="dept-kicker">News</div>\n'
-            '<div class="dept-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
+            '<div class="mg-kicker">News</div>\n'
+            '<div class="mg-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
             "Nobody In The State Capital Will Discuss Openly Today Right Now</div>\n\n"
             "Real body prose so the section has content for the reviewer to read here today.\n"
         )
@@ -122,7 +125,7 @@ class EightTextChecksTest(unittest.TestCase):
 
     def test_1_headline_line_count_flags_a_long_head(self) -> None:
         bad = _review(
-            '<div class="dept-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
+            '<div class="mg-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
             "Nobody In The State Capital Will Discuss Openly Today Right Now This Morning</div>\n\n"
             "Real body prose so the section has content to review here today for the desk.\n"
         )
@@ -134,12 +137,45 @@ class EightTextChecksTest(unittest.TestCase):
 
     def test_2_headline_length_nudges_over_ceiling(self) -> None:
         bad = _review(
-            '<div class="dept-title">Council weighs a fairly modest new plan for the harbor lamps this evening</div>\n\n'
+            '<div class="mg-title">Council weighs a fairly modest new plan for the harbor lamps this evening</div>\n\n'
             "Real body prose for content so the section reads as real to the reviewer here.\n"
         )
         found = self._checks(bad, "headline-length")
         self.assertTrue(found)
         self.assertEqual(found[0]["severity"], "nudge")
+
+    def test_long_dept_title_deck_does_not_flag_length_or_line_count(self) -> None:
+        # the 0.6.0 false positive: a department/deck title is long BY DESIGN
+        # (a multi-sentence summary). It must NOT trip the two LENGTH checks.
+        long_deck = (
+            "Devon's two same-day Monologue notes plus fourteen newsroom commits "
+            "make the lead write itself this morning, and the gap, the connection, "
+            "the drift, and the move are all present and mutually reinforcing today."
+        )
+        report = _review(
+            '<div class="dept-kicker">The Read</div>\n'
+            f'<div class="dept-title">{long_deck}</div>\n\n'
+            "Real body prose so the section reads as genuine content for the desk here today.\n"
+        )
+        self.assertFalse(self._checks(report, "headline-line-count"))
+        self.assertFalse(self._checks(report, "headline-length"))
+
+    def test_real_headline_over_the_line_limit_still_flags(self) -> None:
+        # a TRUE headline (.mg-title) that genuinely runs long is exactly what
+        # the check should still catch — the scope fix must not blind it.
+        report = _review(
+            '<div class="mg-kicker">Harborfront</div>\n'
+            '<div class="mg-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
+            "Nobody In The State Capital Will Discuss Openly Today Right Now This Very Morning</div>\n\n"
+            "Real body prose so the section reads as genuine content for the desk here today.\n"
+        )
+        line_count = self._checks(report, "headline-line-count")
+        length = self._checks(report, "headline-length")
+        self.assertTrue(line_count)
+        self.assertEqual(line_count[0]["severity"], "flag")
+        self.assertGreaterEqual(line_count[0]["measured"]["lines"], 3)
+        self.assertTrue(length)
+        self.assertEqual(length[0]["severity"], "nudge")
 
     def test_3_headline_verb_presence_flags_a_label_head(self) -> None:
         bad = _review(
@@ -226,7 +262,7 @@ class PreferencesTest(unittest.TestCase):
         prefs = Preferences(thresholds={"headline-line-count": {"warn_at_lines": 2}})
         # a 2-line head now flags where the default 3 would not
         ed = _write_edition(
-            '<div class="dept-title">Council weighs a modest plan for the harbor lamps tonight at long last</div>\n\n'
+            '<div class="mg-title">Council weighs a modest plan for the harbor lamps tonight at long last</div>\n\n'
             "Real body prose so the section has content for review here today this morning.\n"
         )
         report = run_review(ed / "edition.md", prefs=prefs)
@@ -249,8 +285,8 @@ class PreferencesTest(unittest.TestCase):
             mutes=[{"check": "headline-length", "when": {"section": "Field Notes"}}]
         )
         ed = _write_edition(
-            '<div class="dept-kicker">Field Notes</div>\n'
-            '<div class="dept-title">Council weighs a fairly modest new plan for the harbor lamps this evening</div>\n\n'
+            '<div class="mg-kicker">Field Notes</div>\n'
+            '<div class="mg-title">Council weighs a fairly modest new plan for the harbor lamps this evening</div>\n\n'
             "Real body prose so the section has content for review here today this morning.\n"
         )
         report = run_review(ed / "edition.md", prefs=prefs)
@@ -311,7 +347,7 @@ class CliReviewTest(unittest.TestCase):
         ed.mkdir(parents=True)
         (ed / "edition.md").write_text(
             '<div class="dept-kicker">News</div>\n'
-            '<div class="dept-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
+            '<div class="mg-title">The Quiet Collapse Of The Municipal Bond Market That Almost '
             "Nobody In The State Capital Will Discuss Openly Today Right Now This Morning</div>\n\n"
             "Real body prose so the section has content for the reviewer to read here today.\n",
             encoding="utf-8",


### PR DESCRIPTION
## The bug (false positive)

`review`'s `headline-line-count` and `headline-length` checks (shipped in 0.6.0) treated **every** composed head identically — `.mg-title`, `.dept-title`, `.oc-title` alike — and flagged each one over the line/character budget.

But `.dept-title` is a broadsheet **department title**: a multi-sentence summary the renderer emits for every read / department / staged item (`renderers.py`), long **by design**. So the two length checks fired on roughly every department title on a normal edition — ~90% false positives. A known-good delivered edition trips the same flags. The net effect was that the one QC gate the `edition` skill tells the editor to act on cried wolf, training the editor to ignore it — which defeats the gate.

## The fix (scope, not threshold)

The two **LENGTH** checks now flag only **TRUE headlines**:

- `.mg-title` — the lead / front headline (demo.md: *"The Lighthouse Keeper Wants a Quieter Lamp"* — a real, tight hed)
- `.article-title` — a printed article's own headline (`article_print.py`)
- `.oc-title` — the field-card main title
- markdown `#`/`##` heads, which double as the head in the simpler packs

…and **exempt** deck / department / section-label elements that are long by design:

- `.dept-title` (department title), `.mg-dek` (deck), `.dept-kicker` / `.mg-kicker` (kickers)

The class → role map is **explicit and documented** in `reviewers.py` — `Headline.role` plus `_TRUE_HEAD_CLASSES` / `_DECK_HEAD_CLASSES` — so it stays maintainable. Decks are still parsed (tagged `role="deck"`), so the other headline checks are **unchanged**: `headline-verb-presence`, `hed-dek-redundancy`, and `duplicate-headline` still read every head regardless of role. A label-style department title with no verb still flags.

## Verified on a real, deck-heavy edition

A broadsheet edition with four long `.dept-title` decks + one genuinely-overlong `.mg-title`:

| | line/length flags | of which deck false positives | overlong real headline flags |
|---|---|---|---|
| **before (0.6.0)** | 10 | 8 | yes |
| **after (0.6.1)** | 2 | **0** | **yes** (line-count flag + length nudge) |

Deck false positives → 0; the genuinely-overlong real headline still flags.

## Tests

- New: a long `.dept-title` deck does **not** trip `headline-line-count` or `headline-length`; a real `.mg-title` over the line/char limit **does** (both the line-count flag and the length nudge).
- Retargeted the existing length-check fixtures from `.dept-title` (now a deck) to `.mg-title` (a true headline).
- Full suite green: **154 passed, 7 skipped**.

Version bumped 0.6.0 → 0.6.1 (`pyproject.toml`, `__init__.py`, `.claude-plugin/plugin.json`); CHANGELOG + `docs/composing.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)